### PR TITLE
Adding mysql native authentication.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       WEBHOOK_SERVER_PORT: 9001
   db:
     image: mysql
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password
     container_name: realdevicemap-db
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Adding mysql_native_password to this version of RDM to prevent issues accessing the DB with other tools, such as php based tools.