### PR TITLE
Added Radius and Store Data option to Leveling Instance

### DIFF
--- a/Sources/RealDeviceMap/Misc/BinaryInteger.swift
+++ b/Sources/RealDeviceMap/Misc/BinaryInteger.swift
@@ -9,6 +9,9 @@ import Foundation
 
 public extension BinaryInteger {
 
+    func toUInt64() -> UInt64 {
+        return UInt64(self)
+    }
     func toUInt32() -> UInt32 {
         return UInt32(self)
     }

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -119,7 +119,7 @@ class WebHookRequestHandler {
 
         let trainerLevel = json["trainerlvl"] as? Int ?? (json["trainerLevel"] as? String)?.toInt() ?? 0
         let trainerXP = json["trainerexp"] as? Int ?? 0
-        var username = json["username"] as? String
+        let username = json["username"] as? String
         if username != nil && trainerLevel > 0 {
             levelCacheLock.lock()
             let oldLevel = levelCache[username!]
@@ -442,6 +442,11 @@ class WebHookRequestHandler {
             try response.respondWithData(data: data)
         } catch {
             response.respondWithError(status: .internalServerError)
+        }
+
+        guard InstanceController.global.shouldStoreData(deviceUUID: uuid ?? "") else {
+            Log.info(message: "[WebHookRequestHandler] Ignoring data for \(uuid ?? "?")")
+            return
         }
 
         let queue = Threading.getQueue(name: Foundation.UUID().uuidString, type: .serial)

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -134,7 +134,7 @@ class WebHookRequestHandler {
             }
         }
 
-        if username != nil {
+        if username != nil && trainerXP > 0 && trainerLevel > 0 {
             InstanceController.global.gotPlayerInfo(username: username!, level: trainerLevel, xp: trainerXP)
         }
 

--- a/resources/webroot/dashboard_instance_add.mustache
+++ b/resources/webroot/dashboard_instance_add.mustache
@@ -10,6 +10,8 @@
                 $('.clear_quests_form').addClass('d-none');
                 $('.spin_limit_text').addClass('d-none');
                 $('.delay_logout_text').addClass('d-none');
+                $('.radius_text').addClass('d-none');
+                $('.store_data_text').addClass('d-none');
             } else if ($(this).val() === 'auto_quest') {
                 $('.pokemon_ids_text').addClass('d-none');
                 $('.scatter_pokemon_ids_text').addClass('d-none');
@@ -17,13 +19,27 @@
                 $('.clear_quests_form').removeClass('d-none');
                 $('.spin_limit_text').removeClass('d-none');
                 $('.delay_logout_text').removeClass('d-none');
+                $('.radius_text').addClass('d-none');
+                $('.store_data_text').addClass('d-none');
+            } else if ($(this).val() === 'leveling') {
+                $('.pokemon_ids_text').addClass('d-none');
+                $('.scatter_pokemon_ids_text').addClass('d-none');
+                $('.iv_queue_limit_text').addClass('d-none');
+                $('.clear_quests_form').addClass('d-none');
+                $('.spin_limit_text').addClass('d-none');
+                $('.delay_logout_text').addClass('d-none');
+                $('.radius_text').removeClass('d-none');
+                $('.store_data_text').removeClass('d-none');
             } else {
                 $('.pokemon_ids_text').addClass('d-none');
                 $('.scatter_pokemon_ids_text').addClass('d-none');
                 $('.iv_queue_limit_text').addClass('d-none');
                 $('.clear_quests_form').addClass('d-none');
                 $('.spin_limit_text').addClass('d-none');
-                $('.delay_logout_text').addClass('d-none');            }
+                $('.delay_logout_text').addClass('d-none');
+                $('.radius_text').addClass('d-none');
+                $('.store_data_text').addClass('d-none');
+            }
         });
     })
 </script>
@@ -87,8 +103,15 @@
                 <input type="number" class="form-control" name="spin_limit" value="{{spin_limit}}" step=1 min="1" max="3500" required>
             </div>
             <div class="form-group delay_logout_text {{^auto_quest_selected}}d-none{{/auto_quest_selected}}">
-                Delay Logout
+                Delay Logout (in seconds, sleep time before account gets swapped)
                 <input type="number" class="form-control" name="delay_logout" value="{{delay_logout}}" step=1 min="60" max="86400" required>
+            </div>
+            <div class="form-group radius_text {{^leveling_selected}}d-none{{/leveling_selected}}">
+                Radius (in meters)
+                <input type="number" class="form-control" name="radius" value="{{radius}}" step=1 min="100" required>
+            </div>
+            <div class="checkbox store_data_text {{^leveling_selected}}d-none{{/leveling_selected}}">
+                <label><input type="checkbox" name="store_data" value="true" {{#store_data}}checked{{/store_data}}> Store Data in Database</label>
             </div>
             <input type="hidden" name="_csrf" value="{{csrf}}">
             <button type="submit" class="btn btn-primary">Create</button>

--- a/resources/webroot/dashboard_instance_edit.mustache
+++ b/resources/webroot/dashboard_instance_edit.mustache
@@ -10,6 +10,8 @@
                 $('.clear_quests_form').addClass('d-none');
                 $('.spin_limit_text').addClass('d-none');
                 $('.delay_logout_text').addClass('d-none');
+                $('.radius_text').addClass('d-none');
+                $('.store_data_text').addClass('d-none');
             } else if ($(this).val() === 'auto_quest') {
                 $('.pokemon_ids_text').addClass('d-none');
                 $('.scatter_pokemon_ids_text').addClass('d-none');
@@ -17,6 +19,17 @@
                 $('.clear_quests_form').removeClass('d-none');
                 $('.spin_limit_text').removeClass('d-none');
                 $('.delay_logout_text').removeClass('d-none');
+                $('.radius_text').addClass('d-none');
+                $('.store_data_text').addClass('d-none');
+            } else if ($(this).val() === 'leveling') {
+                $('.pokemon_ids_text').addClass('d-none');
+                $('.scatter_pokemon_ids_text').addClass('d-none');
+                $('.iv_queue_limit_text').addClass('d-none');
+                $('.clear_quests_form').addClass('d-none');
+                $('.spin_limit_text').addClass('d-none');
+                $('.delay_logout_text').addClass('d-none');
+                $('.radius_text').removeClass('d-none');
+                $('.store_data_text').removeClass('d-none');
             } else {
                 $('.pokemon_ids_text').addClass('d-none');
                 $('.scatter_pokemon_ids_text').addClass('d-none');
@@ -24,6 +37,8 @@
                 $('.clear_quests_form').addClass('d-none');
                 $('.spin_limit_text').addClass('d-none');
                 $('.delay_logout_text').addClass('d-none');
+                $('.radius_text').addClass('d-none');
+                $('.store_data_text').addClass('d-none');
             }
         });
     })
@@ -88,8 +103,15 @@
                 <input type="number" class="form-control" name="spin_limit" value="{{spin_limit}}" step=1 min="1" max="3500" required>
             </div>
             <div class="form-group delay_logout_text {{^auto_quest_selected}}d-none{{/auto_quest_selected}}">
-                Delay Logout
+                Delay Logout (in seconds, sleep time before account gets swapped)
                 <input type="number" class="form-control" name="delay_logout" value="{{delay_logout}}" step=1 min="60" max="86400" required>
+            </div>
+            <div class="form-group radius_text {{^leveling_selected}}d-none{{/leveling_selected}}">
+                Radius (in meters)
+                <input type="number" class="form-control" name="radius" value="{{radius}}" step=1 min="100" required>
+            </div>
+            <div class="checkbox store_data_text {{^leveling_selected}}d-none{{/leveling_selected}}">
+                <label><input type="checkbox" name="store_data" value="true" {{#store_data}}checked{{/store_data}}> Store Data in Database</label>
             </div>
             <input type="hidden" name="_csrf" value="{{csrf}}">
             <button type="submit" class="btn btn-primary">Update</button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds 2 options to Leveling Instances:
- Radius: how far workers are allowed to move away from the center
- Store Data: disable db storage when leveling

Closes #61 and #62

## Motivation and Context
Radius:
- Leveling could start at wrong place. This limits it to within a radius.
Store Data:
- Less stress on DB when leveling

## How Has This Been Tested?
Not yet tested. Just coded

## Screenshots:
![image](https://user-images.githubusercontent.com/1949038/79497588-3980a200-8028-11ea-8439-19fc599d0781.png)


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
