### PR TITLE
Use Instance min/max Level when getting new account

### DIFF
--- a/Sources/RealDeviceMap/Controller/Instance Controllers/InstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/Instance Controllers/InstanceController.swift
@@ -24,6 +24,7 @@ protocol InstanceControllerProto {
     var delegate: InstanceControllerDelegate? { get set }
     func getTask(uuid: String, username: String?) -> [String: Any]
     func getStatus(formatted: Bool) -> JSONConvertible?
+    func getAccount(uuid: String) throws -> Account?
     func reload()
     func stop()
     func shouldStoreData() -> Bool
@@ -39,6 +40,9 @@ extension InstanceControllerProto {
     func gotIV(pokemon: Pokemon) { }
     func gotFortData(fortData: POGOProtos_Map_Fort_FortData, username: String?) { }
     func gotPlayerInfo(username: String, level: Int, xp: Int) { }
+    func getAccount(uuid: String) throws -> Account? {
+        return try Account.getNewAccount(minLevel: minLevel, maxLevel: maxLevel)
+    }
 }
 
 extension InstanceControllerProto {
@@ -297,6 +301,13 @@ class InstanceController {
             return instanceController.shouldStoreData()
         }
         return true
+    }
+
+    public func getAccount(deviceUUID: String) throws -> Account? {
+        if let instanceController = getInstanceController(deviceUUID: deviceUUID) {
+            return try instanceController.getAccount(uuid: deviceUUID)
+        }
+        return try Account.getNewAccount(minLevel: 0, maxLevel: 29)
     }
 
     public func getDeviceUUIDsInInstance(instanceName: String) -> [String] {

--- a/Sources/RealDeviceMap/Modell/Account.swift
+++ b/Sources/RealDeviceMap/Modell/Account.swift
@@ -321,7 +321,7 @@ class Account: WebHookEvent {
         }
     }
 
-    public static func getNewAccount(mysql: MySQL?=nil, minLevel: Int, maxLevel: Int) throws -> Account? {
+    public static func getNewAccount(mysql: MySQL?=nil, minLevel: UInt8, maxLevel: UInt8) throws -> Account? {
 
         guard let mysql = mysql ?? DBController.global.mysql else {
             Log.error(message: "[ACCOUNT] Failed to connect to database.")

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -687,8 +687,6 @@ class WebHookRequestHandler {
         }
 
         let username = jsonO?["username"] as? String
-        let minLevel = jsonO?["min_level"] as? Int ?? 0
-        let maxLevel = jsonO?["max_level"] as? Int ?? 29
 
         guard let mysql = DBController.global.mysql else {
             Log.error(message: "[WebHookRequestHandler] Failed to connect to database.")
@@ -757,31 +755,25 @@ class WebHookRequestHandler {
                 response.respondWithError(status: .notFound)
             }
         } else if type == "get_account" {
-
             do {
-                guard
-                    let device = try Device.getById(mysql: mysql, id: uuid),
-                    let account = try Account.getNewAccount(mysql: mysql, minLevel: minLevel, maxLevel: maxLevel)
-                    else {
-                        response.respondWithError(status: .notFound)
-                        return
+                guard let device = try Device.getById(mysql: mysql, id: uuid) else {
+                    response.respondWithError(status: .notFound)
+                    return
                 }
-                if device.accountUsername != nil {
-                    do {
-                        let oldAccount = try Account.getWithUsername(mysql: mysql, username: device.accountUsername!)
-                        if oldAccount != nil && oldAccount!.firstWarningTimestamp == nil &&
-                           oldAccount!.failed == nil && oldAccount!.failedTimestamp == nil {
-                            try response.respondWithData(data: [
-                                "username": oldAccount!.username,
-                                "password": oldAccount!.password,
-                                "first_warning_timestamp": oldAccount!.firstWarningTimestamp as Any,
-                                "level": oldAccount!.level
-                            ])
-                            return
-                        }
-                    } catch { }
+                if device.accountUsername != nil,
+                   let oldAccount = try Account.getWithUsername(mysql: mysql, username: device.accountUsername!) {
+                    try response.respondWithData(data: [
+                        "username": oldAccount.username,
+                        "password": oldAccount.password,
+                        "first_warning_timestamp": oldAccount.firstWarningTimestamp as Any
+                    ])
+                    return
                 }
-
+                guard let account = try InstanceController.global.getAccount(deviceUUID: uuid) else {
+                    Log.error(message: "[WebHookRequestHandler] Failed to get account for \(uuid)")
+                    response.respondWithError(status: .notFound)
+                    return
+                }
                 device.accountUsername = account.username
                 try device.save(mysql: mysql, oldUUID: device.uuid)
                 try response.respondWithData(data: [
@@ -789,7 +781,6 @@ class WebHookRequestHandler {
                     "password": account.password,
                     "first_warning_timestamp": account.firstWarningTimestamp as Any
                 ])
-
             } catch {
                 response.respondWithError(status: .internalServerError)
             }

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -761,7 +761,8 @@ class WebHookRequestHandler {
                     return
                 }
                 if device.accountUsername != nil,
-                   let oldAccount = try Account.getWithUsername(mysql: mysql, username: device.accountUsername!) {
+                   let oldAccount = try Account.getWithUsername(mysql: mysql, username: device.accountUsername!),
+                   oldAccount.failed == nil {
                     try response.respondWithData(data: [
                         "username": oldAccount.username,
                         "password": oldAccount.password,


### PR DESCRIPTION
## Description
- Use Instance min/max Level when getting new account
- Allow custom get account callback for instance types (not used yet, but e.g. ignore warning for raid instances9

## Motivation and Context
No longer needs low level accounts in db

## How Has This Been Tested?
Not tested yet

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
