### PR TITLE
Parse PlayerData before shouldStoreData check

### DIFF
--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -444,11 +444,6 @@ class WebHookRequestHandler {
             response.respondWithError(status: .internalServerError)
         }
 
-        guard InstanceController.global.shouldStoreData(deviceUUID: uuid ?? "") else {
-            Log.info(message: "[WebHookRequestHandler] Ignoring data for \(uuid ?? "?")")
-            return
-        }
-
         let queue = Threading.getQueue(name: Foundation.UUID().uuidString, type: .serial)
         queue.dispatch {
 
@@ -468,6 +463,11 @@ class WebHookRequestHandler {
                 }
                 Log.debug(message: "[WebHookRequestHandler] Player Detail parsed in " +
                                    "\(String(format: "%.3f", Date().timeIntervalSince(start)))s")
+            }
+            
+            guard InstanceController.global.shouldStoreData(deviceUUID: uuid ?? "") else {
+                Log.info(message: "[WebHookRequestHandler] Ignoring data for \(uuid ?? "?")")
+                return
             }
 
             var gymIdsPerCell = [UInt64: [String]]()

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -464,7 +464,7 @@ class WebHookRequestHandler {
                 Log.debug(message: "[WebHookRequestHandler] Player Detail parsed in " +
                                    "\(String(format: "%.3f", Date().timeIntervalSince(start)))s")
             }
-            
+
             guard InstanceController.global.shouldStoreData(deviceUUID: uuid ?? "") else {
                 Log.info(message: "[WebHookRequestHandler] Ignoring data for \(uuid ?? "?")")
                 return


### PR DESCRIPTION
## Description
Parse PlayerData before shouldStoreData check

## Motivation and Context
Before Leveling Instances with should store data off would ignore GetPlayerData 

## How Has This Been Tested?
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
