### PR TITLE
Implement RAW_THREAD_LIMIT to limit number of concurrent raw requests

### DIFF
--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -492,7 +492,6 @@ class WebHookRequestHandler {
             defer {
                 threadLimitLock.lock()
                 threadLimitCount -= 1
-                print("COUNT", threadLimitCount)
                 threadLimitLock.unlock()
             }
 

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -34,6 +34,10 @@ class WebHookRequestHandler {
     private static var emptyCellsLock = Threading.Lock()
     private static var emptyCells = [UInt64: Int]()
 
+    private static var threadLimitMax = UInt32(ProcessInfo.processInfo.environment["RAW_THREAD_LIMIT"] ?? "") ?? 100
+    private static var threadLimitLock = Threading.Lock()
+    private static var threadLimitCount: UInt32 = 0
+
     static func handle(request: HTTPRequest, response: HTTPResponse, type: WebHookServer.Action) {
 
         let isMadData = request.header(.origin) != nil
@@ -468,6 +472,28 @@ class WebHookRequestHandler {
             guard InstanceController.global.shouldStoreData(deviceUUID: uuid ?? "") else {
                 Log.info(message: "[WebHookRequestHandler] Ignoring data for \(uuid ?? "?")")
                 return
+            }
+
+            threadLimitLock.lock()
+            if threadLimitCount >= threadLimitMax {
+                threadLimitLock.unlock()
+                Log.error(
+                    message: "[WebHookRequestHandler] Reached thread limit of \(threadLimitMax) for /raw. " +
+                              "Ignoring request."
+                )
+                return
+            }
+            threadLimitCount += 1
+            Log.info(
+                message: "[WebHookRequestHandler] Processing /raw request. Currently processing: \(threadLimitCount)"
+            )
+            threadLimitLock.unlock()
+
+            defer {
+                threadLimitLock.lock()
+                threadLimitCount -= 1
+                print("COUNT", threadLimitCount)
+                threadLimitLock.unlock()
             }
 
             var gymIdsPerCell = [UInt64: [String]]()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       WEB_SERVER_PORT: 9000
       WEBHOOK_SERVER_ADDRESS: 0.0.0.0
       WEBHOOK_SERVER_PORT: 9001
+      RAW_THREAD_LIMIT: 100
   db:
     image: mysql
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=86400


### PR DESCRIPTION
## Description
Implement RAW_THREAD_LIMIT to limit number of concurrent raw requests processing threads.
Default: 100

## How Has This Been Tested?
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
