### PR TITLE
Use X-Forwarded-For Header for Login limiting and devices page host

### DIFF
--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -49,37 +49,22 @@ class WebHookRequestHandler {
     static func handle(request: HTTPRequest, response: HTTPResponse, type: WebHookServer.Action) {
 
         let host: String
-        if let remoteAddress = request.connection.remoteAddress {
-            host = remoteAddress.host
+        let forwardedForHeader = request.header(.xForwardedFor) ?? ""
+        if forwardedForHeader.isEmpty || !hostWhitelistUsesProxy {
+            host = request.remoteAddress.host
         } else {
-            host = "?"
+            host = forwardedForHeader
         }
 
         let isMadData = request.header(.origin) != nil
 
         if let hostWhitelist = hostWhitelist {
-            let host: String
-            let forwardedForHeader = request.header(.xForwardedFor) ?? ""
-            if forwardedForHeader.isEmpty || !hostWhitelistUsesProxy {
-                host = request.remoteAddress.host
-            } else {
-                host = forwardedForHeader
-            }
-
             guard hostWhitelist.contains(host) else {
                 return response.respondWithError(status: .unauthorized)
             }
         }
 
         if let loginSecret = loginSecret {
-            let host: String
-            let forwardedForHeader = request.header(.xForwardedFor) ?? ""
-            if forwardedForHeader.isEmpty || !hostWhitelistUsesProxy {
-                host = request.remoteAddress.host
-            } else {
-                host = forwardedForHeader
-            }
-
             guard WebHookRequestHandler.limiter.allowed(host: host) else {
                 return response.respondWithError(status: .unauthorized)
             }


### PR DESCRIPTION
## Description
- Use X-Forwarded-For Header instead of address to determine host if "Device Endpoint is behind proxy" is enabled
- Used by login limiter and devices page host column

## Motivation and Context
Fix login limiting behind proxy

## How Has This Been Tested?
Not tested

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
