### PR TITLE
Fixes Incorrect Spawnpoint Longitude 

### DIFF
--- a/Sources/RealDeviceMap/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMap/Modell/Pokemon.swift
@@ -341,7 +341,7 @@ class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStringConve
             let spawnId = UInt64(encounterData.wildPokemon.spawnPointID, radix: 16)
             self.spawnId = spawnId
             self.lat = encounterData.wildPokemon.latitude
-            self.lat = encounterData.wildPokemon.latitude
+            self.lon = encounterData.wildPokemon.longitude
 
             if !expireTimestampVerified && spawnId != nil {
                 let spawnpoint: SpawnPoint?


### PR DESCRIPTION
## Description
- Fixes spawnpoint longitude sometimes being set to pokestop longitude

## How Has This Been Tested?
No but pretty sure that should fix it
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
