### PR TITLE
Fix S2Cell WebHook Weather Event Naming

### DIFF
--- a/Sources/RealDeviceMap/Modell/Weather.swift
+++ b/Sources/RealDeviceMap/Modell/Weather.swift
@@ -60,7 +60,7 @@ class Weather: JSONConvertibleObject, WebHookEvent {
         }
 
         let message: [String: Any] = [
-            "id": id,
+            "s2_cell_id": id,
             "latitude": latitude,
             "longitude": longitude,
             "polygon": polygon,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Change weather event name of field `id` to `s2_cell_id` to match other events

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix anyissues they point out. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
