### PR TITLE
Simple Pokestop Clustering for Questing

### DIFF
--- a/Sources/RealDeviceMap/Controller/Instance Controllers/AutoInstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/Instance Controllers/AutoInstanceController.swift
@@ -335,13 +335,23 @@ class AutoInstanceController: InstanceControllerProto {
                     }
 
                     if closest == nil {
-                         return [String: Any]()
+                        return [String: Any]()
                     }
-
                     pokestop = closest!
+
+                    var nearbyStops = [pokestop]
+                    let pokestopCoord = Coord(lat: pokestop.lat, lon: pokestop.lon)
+                    for stop in todayStopsC! {
+                        // MARK: Revert back to 40m once reverted ingame
+                        if pokestopCoord.distance(to: Coord(lat: stop.lat, lon: stop.lon)) <= 80 {
+                            nearbyStops.append(stop)
+                        }
+                    }
                     stopsLock.lock()
-                    if let index = todayStops!.index(of: pokestop) {
-                        todayStops!.remove(at: index)
+                    for pokestop in nearbyStops {
+                        if let index = todayStops!.index(of: pokestop) {
+                            todayStops!.remove(at: index)
+                        }
                     }
                     stopsLock.unlock()
                 } else {

--- a/Sources/RealDeviceMap/Controller/Instance Controllers/LevelingInstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/Instance Controllers/LevelingInstanceController.swift
@@ -189,7 +189,8 @@ class LevelingInstanceController: InstanceControllerProto {
         unspunLoop: for stop in unspunPokestops {
             let coord = Coord(lat: stop.latitude, lon: stop.longitude)
             for last in exclude {
-                if coord.distance(to: last) <= 40 {
+                // MARK: Revert back to 40m once reverted ingame
+                if coord.distance(to: last) <= 80 {
                     continue unspunLoop
                 }
             }


### PR DESCRIPTION
##  Description
- Add simple Pokestop clustering for questing
- Update Leveling (and Questing) cluster range from 40m to 80m temporarily

## Motivation and Context
This change assumes the usage of "Ultra Quest".

## How Has This Been Tested?
Not tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
