### PR TITLE
Fix Account Assignment Collisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Swift
 .build/
-.swiftpm/
+.build_lin/
 .packages_lin/
 Package.resolved
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Swift
 .build/
-.build_lin/
+.swiftpm/
 .packages_lin/
 Package.resolved
 

--- a/Sources/RealDeviceMap/Controller/Instance Controllers/AutoInstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/Instance Controllers/AutoInstanceController.swift
@@ -375,6 +375,10 @@ class AutoInstanceController: InstanceControllerProto {
                             accountsLock.lock()
                             newUsername = account?.username
                             accounts[uuid] = account?.username
+                            Log.debug(
+                                message: "[AutoInstanceController] [\(name)] [\(uuid)] Over Logout Delay. " +
+                                         "Switching Account from \(username ?? "?") to \(newUsername ?? "?")"
+                            )
                         } else {
                             newUsername = accounts[uuid]
                         }
@@ -384,10 +388,6 @@ class AutoInstanceController: InstanceControllerProto {
                             message: "[AutoInstanceController] [\(name)] [\(uuid)] Failed to get account in advance."
                         )
                     }
-                    Log.debug(
-                        message: "[AutoInstanceController] [\(name)] [\(uuid)] Over Logout Delay. " +
-                                 "Switching Account from \(username ?? "?") to \(newUsername ?? "?")"
-                    )
                     return ["action": "switch_account", "min_level": minLevel, "max_level": maxLevel]
                 }
 
@@ -550,7 +550,8 @@ class AutoInstanceController: InstanceControllerProto {
                 ignoringWarning: true,
                 spins: spinLimit,
                 noCooldown: true,
-                encounterTarget: encounterTarget
+                encounterTarget: encounterTarget,
+                device: uuid
             )
         }
     }

--- a/Sources/RealDeviceMap/Controller/Instance Controllers/CircleInstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/Instance Controllers/CircleInstanceController.swift
@@ -99,7 +99,8 @@ class CircleInstanceController: InstanceControllerProto {
                 maxLevel: maxLevel,
                 ignoringWarning: false,
                 spins: nil,
-                noCooldown: false
+                noCooldown: false,
+                device: uuid
             )
         case .raid:
             return try Account.getNewAccount(
@@ -108,7 +109,8 @@ class CircleInstanceController: InstanceControllerProto {
                 maxLevel: maxLevel,
                 ignoringWarning: true,
                 spins: nil,
-                noCooldown: false
+                noCooldown: false,
+                device: uuid
             )
         }
     }

--- a/Sources/RealDeviceMap/Controller/Instance Controllers/CircleSmartRaidInstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/Instance Controllers/CircleSmartRaidInstanceController.swift
@@ -205,7 +205,8 @@ class CircleSmartRaidInstanceController: CircleInstanceController {
             maxLevel: maxLevel,
             ignoringWarning: true,
             spins: nil,
-            noCooldown: false
+            noCooldown: false,
+            device: uuid
         )
     }
 

--- a/Sources/RealDeviceMap/Controller/Instance Controllers/IVInstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/Instance Controllers/IVInstanceController.swift
@@ -236,7 +236,8 @@ class IVInstanceController: InstanceControllerProto {
             maxLevel: maxLevel,
             ignoringWarning: false,
             spins: nil,
-            noCooldown: false
+            noCooldown: false,
+            device: uuid
         )
     }
 

--- a/Sources/RealDeviceMap/Controller/Instance Controllers/InstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/Instance Controllers/InstanceController.swift
@@ -43,7 +43,7 @@ extension InstanceControllerProto {
     func gotFortData(fortData: POGOProtos_Map_Fort_FortData, username: String?) { }
     func gotPlayerInfo(username: String, level: Int, xp: Int) { }
     func getAccount(mysql: MySQL, uuid: String) throws -> Account? {
-        return try Account.getNewAccount(mysql: mysql, minLevel: minLevel, maxLevel: maxLevel)
+        return try Account.getNewAccount(mysql: mysql, minLevel: minLevel, maxLevel: maxLevel, device: uuid)
     }
     func accountValid(account: Account) -> Bool {
         return account.level >= minLevel && account.level <= maxLevel && account.isValid()
@@ -312,7 +312,7 @@ class InstanceController {
         if let instanceController = getInstanceController(deviceUUID: deviceUUID) {
             return try instanceController.getAccount(mysql: mysql, uuid: deviceUUID)
         }
-        return try Account.getNewAccount(minLevel: 0, maxLevel: 29)
+        return try Account.getNewAccount(minLevel: 0, maxLevel: 29, device: deviceUUID)
     }
 
     public func accountValid(deviceUUID: String, account: Account) -> Bool {

--- a/Sources/RealDeviceMap/Controller/Instance Controllers/LevelingInstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/Instance Controllers/LevelingInstanceController.swift
@@ -332,7 +332,8 @@ class LevelingInstanceController: InstanceControllerProto {
             maxLevel: maxLevel,
             ignoringWarning: false,
             spins: nil, // 7000
-            noCooldown: true
+            noCooldown: true,
+            device: uuid
         )
     }
 

--- a/Sources/RealDeviceMap/Modell/Account.swift
+++ b/Sources/RealDeviceMap/Modell/Account.swift
@@ -446,10 +446,8 @@ class Account: WebHookEvent {
         Account.lockoutLock.lock()
         let now = Date()
         var newAccounts = [(account: String, device: String, untill: Date)]()
-        for lockout in Account.lockouts {
-            if (lockout.untill) >= now {
-                newAccounts.append(lockout)
-            }
+        for lockout in Account.lockouts where (lockout.untill) >= now {
+            newAccounts.append(lockout)
         }
         Account.lockouts = newAccounts
         let locked = Account.lockouts.filter { (lockout) -> Bool in

--- a/Sources/RealDeviceMap/Modell/Account.swift
+++ b/Sources/RealDeviceMap/Modell/Account.swift
@@ -10,9 +10,13 @@
 import Foundation
 import PerfectLib
 import PerfectMySQL
+import PerfectThread
 import POGOProtos
 
 class Account: WebHookEvent {
+
+    private static let lockoutLock = Threading.Lock()
+    private static var lockouts = [(account: String, device: String, untill: Date)]()
 
     func getWebhookValues(type: String) -> [String: Any] {
 
@@ -373,7 +377,8 @@ class Account: WebHookEvent {
 
     public static func getNewAccount(mysql: MySQL?=nil, minLevel: UInt8, maxLevel: UInt8,
                                      ignoringWarning: Bool=false, spins: Int?=1000,
-                                     noCooldown: Bool=true, encounterTarget: Coord?=nil) throws -> Account? {
+                                     noCooldown: Bool=true, encounterTarget: Coord?=nil,
+                                     device: String) throws -> Account? {
 
         guard let mysql = mysql ?? DBController.global.mysql else {
             Log.error(message: "[ACCOUNT] Failed to connect to database.")
@@ -438,6 +443,26 @@ class Account: WebHookEvent {
             cooldownSQL = ""
         }
 
+        Account.lockoutLock.lock()
+        let now = Date()
+        Account.lockouts.removeAll { (lockout) -> Bool in
+            lockout.untill <= now
+        }
+        let locked = Account.lockouts.filter { (lockout) -> Bool in
+            return lockout.device != device
+        }.map { (lockout) -> String in
+            return lockout.account
+        }
+        Account.lockoutLock.unlock()
+
+        let lockoutSQL: String
+        if !locked.isEmpty {
+            let paramString = [String].init(repeating: "?", count: locked.count).joined(separator: ", ")
+            lockoutSQL = "AND username NOT IN (\(paramString))"
+        } else {
+            lockoutSQL = ""
+        }
+
         let sql = """
             SELECT username, password, level, first_warning_timestamp, failed_timestamp, failed, last_encounter_lat,
                 last_encounter_lon, last_encounter_time, spins, creation_timestamp, warn, warn_expire_timestamp,
@@ -451,6 +476,7 @@ class Account: WebHookEvent {
                 \(failedSQL)
                 \(spinSQL)
                 \(cooldownSQL)
+                \(lockoutSQL)
             ORDER BY level DESC, last_used_timestamp DESC
             LIMIT 1
         """
@@ -465,6 +491,11 @@ class Account: WebHookEvent {
         if noCooldown, let encounterTarget = encounterTarget {
             mysqlStmt.bindParam(encounterTarget.lon)
             mysqlStmt.bindParam(encounterTarget.lat)
+        }
+        if !locked.isEmpty {
+            for username in locked {
+                mysqlStmt.bindParam(username)
+            }
         }
 
         guard mysqlStmt.execute() else {
@@ -496,6 +527,10 @@ class Account: WebHookEvent {
         let wasSuspended = result[15] as? Bool
         let banned = result[16] as? Bool
         let lastUsedTimestamp = result[17] as? UInt32
+
+        Account.lockoutLock.lock()
+        Account.lockouts.append((account: username, device: device, untill: now.addingTimeInterval(300)))
+        Account.lockoutLock.unlock()
 
         try? Account.setLastUsed(mysql: mysql, username: username)
         return Account(

--- a/Sources/RealDeviceMap/Modell/Account.swift
+++ b/Sources/RealDeviceMap/Modell/Account.swift
@@ -445,9 +445,13 @@ class Account: WebHookEvent {
 
         Account.lockoutLock.lock()
         let now = Date()
-        Account.lockouts.removeAll { (lockout) -> Bool in
-            lockout.untill <= now
+        var newAccounts = [(account: String, device: String, untill: Date)]()
+        for lockout in Account.lockouts {
+            if (lockout.untill) >= now {
+                newAccounts.append(lockout)
+            }
         }
+        Account.lockouts = newAccounts
         let locked = Account.lockouts.filter { (lockout) -> Bool in
             return lockout.device != device
         }.map { (lockout) -> String in

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -845,12 +845,6 @@ class WebHookRequestHandler {
                     }
                     account = newAccount
                 }
-                device.accountUsername = account!.username
-                try device.save(mysql: mysql, oldUUID: device.uuid)
-                try response.respondWithData(data: [
-                    "username": account!.username,
-                    "password": account!.password
-                ])
 
                 if username != account!.username, let loginLimit = self.loginLimit {
                     let currentTime = UInt32(Date().timeIntervalSince1970) / loginLimitIntervall
@@ -884,6 +878,8 @@ class WebHookRequestHandler {
                     Log.debug(message: "[WebHookRequestHandler] [\(uuid)] New account: \(account!.username)")
                 }
 
+                device.accountUsername = account!.username
+                try device.save(mysql: mysql, oldUUID: device.uuid)
                 try response.respondWithData(data: [
                     "username": account!.username,
                     "password": account!.password


### PR DESCRIPTION
##  Description
- Fix cases where getting new account could return the same account for two devices (which resulted in a constraint fail

## Motivation and Context
This would potentially slow down switching to an valid account

## How Has This Been Tested?
Not tested yet

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
