### PR TITLE
Fix cols for gyms without active raid

### DIFF
--- a/resources/webroot/index.js.mustache
+++ b/resources/webroot/index.js.mustache
@@ -2416,14 +2416,14 @@ function getGymPopupContent (gym) {
               : ''
       var url = gym.url.replace('http://', 'https://')
       content +=
-            '<div class="col-6 col-md-4">' + // START 1ST COL
+            '<div class="col-6 col-md-5">' + // START 1ST COL
                 // '<a href="' + url + '" target="_blank"><img src="' + url + '" style="border-radius:50%; height:96px; width:96px;"></a>' +
                 '<a href="' + url + '" target="_blank"><img src="' + url + '" class="circle-image ' + teamClass + '" style="height:96px; width:96px;"></a>' +
             '</div>' // END 1ST COL
     }
     content +=
             // '<div class="col-12 col-md-8 ' + (hasGymUrl ? 'text-center' : '') + ' center-vertical">' + //START 2ND COL
-            '<div class="col-12 col-md-8 center-vertical p-4">' + // START 2ND COL
+            '<div class="col-12 col-md-7 center-vertical p-4">' + // START 2ND COL
                 '<b>Team:</b> ' + getTeamName(gym.team_id) + '<br>' +
                 '<b>Slots Available:</b> ' + (gym.availble_slots === 0 ? 'Full' : gym.availble_slots === 6 ? 'Empty' : gym.availble_slots) + '<br>'
     if (gym.guard_pokemon_id !== null) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Show gym popup when raid is not active
## Description
<!--- Describe your changes in detail -->
Change cols % in order to fix overlapping

## Motivation and Context
Wrong position overlapping text with gym image

## How Has This Been Tested?
locally

## Screenshots (if appropriate):
Before
![Screenshot from 2020-06-05 11-49-31](https://user-images.githubusercontent.com/20624591/83863542-c17b5200-a723-11ea-877b-be61755a4399.png)

After
![Screenshot from 2020-06-05 11-48-21](https://user-images.githubusercontent.com/20624591/83863562-c5a76f80-a723-11ea-9dd2-99a63048cc87.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix anyissues they point out. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
