### PR TITLE
Return Version and Commit in DeviceAPI init call (and Header)

### DIFF
--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -735,38 +735,27 @@ class WebHookRequestHandler {
         if type == "init" {
             do {
                 let device = try Device.getById(mysql: mysql, id: uuid)
+                let assigned: Bool
                 if device == nil {
                     let newDevice = Device(uuid: uuid, instanceName: nil, lastHost: nil, lastSeen: 0,
                                            accountUsername: nil, lastLat: 0.0, lastLon: 0.0, deviceGroup: nil)
                     try newDevice.create(mysql: mysql)
-                    try response.respondWithData(
-                        data: [
-                            "assigned": false,
-                            "version": VersionManager.global.version,
-                            "commit": VersionManager.global.commit,
-                            "provider": "RealDeviceMap"
-                        ]
-                    )
+                    assigned = false
                 } else {
                     if device!.instanceName == nil {
-                        try response.respondWithData(
-                            data: [
-                                "assigned": false,
-                                "version": VersionManager.global.version,
-                                "commit": VersionManager.global.commit,
-                                "provider": "RealDeviceMap"
-                            ]
-                        )
+                        assigned = false
                     } else {
-                        try response.respondWithData(
-                            data: [
-                                "assigned": true,
-                                "version": VersionManager.global.version,
-                                "commit": VersionManager.global.commit
-                            ]
-                        )
+                        assigned = true
                     }
                 }
+                try response.respondWithData(
+                    data: [
+                        "assigned": assigned,
+                        "version": VersionManager.global.version,
+                        "commit": VersionManager.global.commit,
+                        "provider": "RealDeviceMap"
+                    ]
+                )
             } catch {
                 response.respondWithError(status: .internalServerError)
             }

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -79,7 +79,7 @@ class WebHookRequestHandler {
                 return response.respondWithError(status: .unauthorized)
             }
         }
-
+        response.addHeader(.server, value: "RealDeviceMap/\(VersionManager.global.version)")
         switch type {
         case .controler:
             controlerHandler(request: request, response: response, host: host)

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -735,33 +735,33 @@ class WebHookRequestHandler {
         if type == "init" {
             do {
                 let device = try Device.getById(mysql: mysql, id: uuid)
-                let firstWarningTimestamp: UInt32?
-                if device == nil || device!.accountUsername == nil {
-                    firstWarningTimestamp = nil
-                } else {
-                    let account = try Account.getWithUsername(mysql: mysql, username: device!.accountUsername!)
-                    if account != nil {
-                        firstWarningTimestamp = account!.firstWarningTimestamp
-                    } else {
-                        firstWarningTimestamp = nil
-                    }
-                }
-
                 if device == nil {
                     let newDevice = Device(uuid: uuid, instanceName: nil, lastHost: nil, lastSeen: 0,
                                            accountUsername: nil, lastLat: 0.0, lastLon: 0.0, deviceGroup: nil)
                     try newDevice.create(mysql: mysql)
                     try response.respondWithData(
-                        data: ["assigned": false, "first_warning_timestamp": firstWarningTimestamp as Any]
+                        data: [
+                            "assigned": false,
+                            "version": VersionManager.global.version,
+                            "commit":  VersionManager.global.commit
+                        ]
                     )
                 } else {
                     if device!.instanceName == nil {
                         try response.respondWithData(
-                            data: ["assigned": false, "first_warning_timestamp": firstWarningTimestamp as Any]
+                            data: [
+                                "assigned": false,
+                                "version": VersionManager.global.version,
+                                "commit":  VersionManager.global.commit
+                            ]
                         )
                     } else {
                         try response.respondWithData(
-                            data: ["assigned": true, "first_warning_timestamp": firstWarningTimestamp as Any]
+                            data: [
+                                "assigned": true,
+                                "version": VersionManager.global.version,
+                                "commit":  VersionManager.global.commit
+                            ]
                         )
                     }
                 }

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -79,7 +79,7 @@ class WebHookRequestHandler {
                 return response.respondWithError(status: .unauthorized)
             }
         }
-        response.addHeader(.server, value: "RealDeviceMap/\(VersionManager.global.version)")
+        response.addHeader(.custom(name: "X-Server"), value: "RealDeviceMap/\(VersionManager.global.version)")
         switch type {
         case .controler:
             controlerHandler(request: request, response: response, host: host)
@@ -762,7 +762,7 @@ class WebHookRequestHandler {
                             data: [
                                 "assigned": true,
                                 "version": VersionManager.global.version,
-                                "commit":  VersionManager.global.commit
+                                "commit": VersionManager.global.commit
                             ]
                         )
                     }

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -743,7 +743,8 @@ class WebHookRequestHandler {
                         data: [
                             "assigned": false,
                             "version": VersionManager.global.version,
-                            "commit":  VersionManager.global.commit
+                            "commit": VersionManager.global.commit,
+                            "provider": "RealDeviceMap"
                         ]
                     )
                 } else {
@@ -752,7 +753,8 @@ class WebHookRequestHandler {
                             data: [
                                 "assigned": false,
                                 "version": VersionManager.global.version,
-                                "commit":  VersionManager.global.commit
+                                "commit": VersionManager.global.commit,
+                                "provider": "RealDeviceMap"
                             ]
                         )
                     } else {


### PR DESCRIPTION
##  Description
- added `version`, `commit` and `provider` in DeviceAPI `/controler` `init` response
- added `X-Server` header with `RealDevicemap/{Version}` to `/controler` requests


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
