### PR TITLE
Fix Migration 64

### DIFF
--- a/resources/migrations/64.sql
+++ b/resources/migrations/64.sql
@@ -3,7 +3,7 @@ DROP FOREIGN KEY `assignment_fk_device_uuid`,
 ADD COLUMN id INT UNSIGNED AUTO_INCREMENT NOT NULL,
 DROP PRIMARY KEY,
 ADD PRIMARY KEY (id),
-MODIFY COLUMN device_uuid VARCHAR(30) NULL;
+MODIFY COLUMN device_uuid VARCHAR(40) NULL;
 
 ALTER TABLE assignment
 ADD CONSTRAINT `assignment_fk_device_uuid` FOREIGN KEY (`device_uuid`) REFERENCES `device`(`uuid`) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -22,7 +22,7 @@ DROP COLUMN instance_name;
 
 CREATE TABLE device_group_device (
     device_group_name VARCHAR(30) NOT NULL,
-    device_uuid VARCHAR(30) NOT NULL,
+    device_uuid VARCHAR(40) NOT NULL,
     PRIMARY KEY (device_group_name, device_uuid),
     CONSTRAINT `device_group_device_fk_device_group_name` FOREIGN KEY (`device_group_name`) REFERENCES `device_group`(`name`) ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT `device_group_device_fk_device_uuid` FOREIGN KEY (`device_uuid`) REFERENCES `device`(`uuid`) ON DELETE CASCADE ON UPDATE CASCADE


### PR DESCRIPTION
- Fixes wrong name length in migration 64
- If you already ran that migration run this to fix it:
```
ALTER TABLE assignment
MODIFY COLUMN device_uuid VARCHAR(40) NULL;
ALTER TABLE device_group_device
MODIFY COLUMN device_uuid VARCHAR(40) NOT NULL;
```