### PR TITLE
Ignore SIGPIPE in LLDB 

### DIFF
--- a/Sources/RealDeviceMap/Misc/main.swift
+++ b/Sources/RealDeviceMap/Misc/main.swift
@@ -293,9 +293,6 @@ startupServerContext = nil
 
 ApiRequestHandler.start = Date()
 
-// Ignore SIGPIPE
-signal(SIGPIPE, SIG_IGN)
-
 Log.info(message: "[MAIN] Starting Webserves")
 do {
     try HTTPServer.launch(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 #     NO_BACKUP: 1
 ### Uncommenting The following lines will start RDM in lldb and store crash reports in the backups folder
 ### Running in lldb will use a bit more resources. (Running RDM works like usual)
-# entrypoint: ["/bin/sh", "-c", "lldb -b -o \"file ./RealDeviceMap\" -o \"breakpoint set --file main.swift --line 17\" -o \"run\" -o \"process handle SIGPIPE -n true -p true -s false\" -o \"continue\" -k \"bugreport unwind --outfile ./backups/crash-$$(date +%s).log\" -k \"exit\""]
+#   entrypoint: ["/bin/sh", "-c", "lldb -b -o \"file ./RealDeviceMap\" -o \"breakpoint set --file main.swift --line 17\" -o \"run\" -o \"process handle SIGPIPE -n true -p true -s false\" -o \"continue\" -k \"bugreport unwind --outfile ./backups/crash-$$(date +%s).log\" -k \"exit\""]
 #   cap_add:
 #     - SYS_ADMIN
 #   security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 #     NO_BACKUP: 1
 ### Uncommenting The following lines will start RDM in lldb and store crash reports in the backups folder
 ### Running in lldb will use a bit more resources. (Running RDM works like usual)
-#   entrypoint: ["/bin/sh", "-c", "lldb -b -o \"file ./RealDeviceMap\" -o \"run\" -k \"bugreport unwind --outfile ./backups/crash-$$(date +%s).log\" -k \"exit\""]
+# entrypoint: ["/bin/sh", "-c", "lldb -b -o \"file ./RealDeviceMap\" -o \"breakpoint set --file main.swift --line 17\" -o \"run\" -o \"process handle SIGPIPE -n true -p true -s false\" -o \"continue\" -k \"bugreport unwind --outfile ./backups/crash-$$(date +%s).log\" -k \"exit\""]
 #   cap_add:
 #     - SYS_ADMIN
 #   security_opt:


### PR DESCRIPTION
## Description
- Update LLDB command in example docker-compose.yml to ignore SIGPIPE

## Motivation and Context
In normal RDM operation we ignore SIGPIPE. However when running in LLDB this is not the case.
The updated LLDB entrypoint fixes this.

## How Has This Been Tested?
Currently Testing it.
It works if no SIGPIPE crash reports occour any more

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
