### PR TITLE
Trainer XP from holo inventory with ability to save data in database

### DIFF
--- a/Sources/RealDeviceMap/Controller/InstanceControllers/InstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/InstanceControllers/InstanceController.swift
@@ -32,6 +32,7 @@ protocol InstanceControllerProto {
     func reload()
     func stop()
     func shouldStoreData() -> Bool
+    func shouldStoreExp() -> Bool
     func gotPokemon(pokemon: Pokemon)
     func gotIV(pokemon: Pokemon)
     func gotFortData(fortData: PokemonFortProto, username: String?)
@@ -40,6 +41,7 @@ protocol InstanceControllerProto {
 
 extension InstanceControllerProto {
     func shouldStoreData() -> Bool { return true }
+    func shouldStoreExp() -> Bool { return false }
     func gotPokemon(pokemon: Pokemon) { }
     func gotIV(pokemon: Pokemon) { }
     func gotFortData(fortData: PokemonFortProto, username: String?) { }
@@ -231,12 +233,14 @@ class InstanceController {
             let isEvent = instance.data["is_event"] as? Bool ?? false
             let radius = instance.data["radius"] as? UInt64 ?? (instance.data["radius"] as? Int)?.toUInt64() ?? 100000
             let storeData = instance.data["store_data"] as? Bool ?? false
+            let storeExp = instance.data["store_exp"] as? Bool ?? false
             instanceController = LevelingInstanceController(
                 name: instance.name,
                 start: coord,
                 minLevel: minLevel,
                 maxLevel: maxLevel,
                 storeData: storeData,
+                storeExp: storeExp,
                 radius: radius,
                 accountGroup: accountGroup,
                 isEvent: isEvent
@@ -328,6 +332,13 @@ class InstanceController {
             return instanceController.shouldStoreData()
         }
         return true
+    }
+
+    public func shouldStoreExp(deviceUUID: String) -> Bool {
+        if let instanceController = getInstanceController(deviceUUID: deviceUUID) {
+            return instanceController.shouldStoreExp()
+        }
+        return false
     }
 
     public func getAccount(mysql: MySQL, deviceUUID: String) throws -> Account? {

--- a/Sources/RealDeviceMap/Controller/InstanceControllers/LevelingInstanceController.swift
+++ b/Sources/RealDeviceMap/Controller/InstanceControllers/LevelingInstanceController.swift
@@ -68,6 +68,7 @@ class LevelingInstanceController: InstanceControllerProto {
 
     private let start: Coord
     private let storeData: Bool
+    private let storeExp: Bool
     private let radius: UInt64
     private let unspunPokestopsPerUsernameLock = NSLock()
     private var unspunPokestopsPerUsername = [String: [String: PokemonFortProto]]()
@@ -80,7 +81,7 @@ class LevelingInstanceController: InstanceControllerProto {
     private var lastLocactionUsername = [String: Coord]()
 
     init(name: String, start: Coord, minLevel: UInt8, maxLevel: UInt8, storeData: Bool,
-         radius: UInt64, accountGroup: String?, isEvent: Bool) {
+         storeExp: Bool, radius: UInt64, accountGroup: String?, isEvent: Bool) {
         self.name = name
         self.minLevel = minLevel
         self.maxLevel = maxLevel
@@ -88,6 +89,7 @@ class LevelingInstanceController: InstanceControllerProto {
         self.isEvent = isEvent
         self.start = start
         self.storeData = storeData
+        self.storeExp = storeExp
         self.radius = radius
     }
 
@@ -321,6 +323,10 @@ class LevelingInstanceController: InstanceControllerProto {
 
     func shouldStoreData() -> Bool {
         return storeData
+    }
+
+    func shouldStoreExp() -> Bool {
+        return storeExp
     }
 
     func reload() {

--- a/Sources/RealDeviceMap/Modell/Account.swift
+++ b/Sources/RealDeviceMap/Modell/Account.swift
@@ -300,6 +300,29 @@ class Account: WebHookEvent {
         }
     }
 
+    public static func setTotalExp(mysql: MySQL?=nil, username: String, totalExp: Int) throws {
+
+        guard let mysql = mysql ?? DBController.global.mysql else {
+            Log.error(message: "[ACCOUNT] Failed to connect to database.")
+            throw DBController.DBError()
+        }
+
+        let mysqlStmt = MySQLStmt(mysql)
+        let sql = """
+                UPDATE account
+                SET total_exp = ?
+                WHERE username = ?
+            """
+        _ = mysqlStmt.prepare(statement: sql)
+        mysqlStmt.bindParam(totalExp)
+        mysqlStmt.bindParam(username)
+
+        guard mysqlStmt.execute() else {
+            Log.error(message: "[ACCOUNT] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            throw DBController.DBError()
+        }
+    }
+
     public static func didEncounter(mysql: MySQL?=nil, username: String, lon: Double,
                                     lat: Double, time: UInt32) throws {
 

--- a/Sources/RealDeviceMap/Web/WebRequestHandler.swift
+++ b/Sources/RealDeviceMap/Web/WebRequestHandler.swift
@@ -688,6 +688,7 @@ class WebRequestHandler {
                 data["delay_logout"] = 900
                 data["radius"] = 10000
                 data["store_data"] = false
+                data["store_exp"] = false
                 data["nothing_selected"] = true
                 data["account_group"] = nil
                 data["is_event"] = false
@@ -2226,6 +2227,7 @@ class WebRequestHandler {
         let delayLogout = Int(request.param(name: "delay_logout") ?? "" ) ?? 900
         let radius = UInt64(request.param(name: "radius") ?? "" ) ?? 10000
         let storeData = request.param(name: "store_data") == "true"
+        let storeExp = request.param(name: "store_exp") == "true"
         let accountGroup = request.param(name: "account_group")?.emptyToNil()
         let isEvent = request.param(name: "is_event") == "true"
 
@@ -2241,6 +2243,7 @@ class WebRequestHandler {
         data["delay_logout"] = delayLogout
         data["radius"] = radius
         data["store_data"] = storeData
+        data["store_exp"] = storeExp
         data["account_group"] = accountGroup
         data["is_event"] = isEvent
 
@@ -2376,6 +2379,7 @@ class WebRequestHandler {
                 } else if type == .leveling {
                     oldInstance!.data["radius"] = radius
                     oldInstance!.data["store_data"] = storeData
+                    oldInstance!.data["store_exp"] = storeExp
                 }
                 do {
                     try oldInstance!.update(oldName: instanceName!)
@@ -2410,6 +2414,7 @@ class WebRequestHandler {
             } else if type == .leveling {
                 instanceData["radius"] = radius
                 instanceData["store_data"] = storeData
+                instanceData["store_exp"] = storeExp
             }
             let instance = Instance(name: name, type: type!, data: instanceData, count: 0)
             do {
@@ -2485,6 +2490,7 @@ class WebRequestHandler {
             data["delay_logout"] = oldInstance!.data["delay_logout"] as? Int ?? 900
             data["radius"] = (oldInstance!.data["radius"] as? Int)?.toUInt64() ?? 100000
             data["store_data"] = oldInstance!.data["store_data"] as? Bool ?? false
+            data["store_exp"] = oldInstance!.data["store_exp"] as? Bool ?? false
             data["account_group"] = (oldInstance!.data["account_group"] as? String)?.emptyToNil()
             data["is_event"] = oldInstance!.data["is_event"] as? Bool ?? false
 

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -489,7 +489,7 @@ class WebHookRequestHandler {
             if !holodatas.isEmpty && username != nil {
                 let start = Date()
                 for holodata in holodatas {
-                    let items = holodata.inventoryDelta.inventoryItems
+                    let items = holodata.inventoryDelta.inventoryItem
                     for item in items {
                         let playerstats = item.inventoryItemData.playerStats
                         trainerXP = Int(playerstats.experience) > 0 ? Int(playerstats.experience) : trainerXP

--- a/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMap/Webhook/WebHookRequestHandler.swift
@@ -31,6 +31,9 @@ class WebHookRequestHandler {
     private static let levelCacheLock = Threading.Lock()
     private static var levelCache = [String: Int]()
 
+    private static let expCacheLock = Threading.Lock()
+    private static var expCache = [String: Int]()
+
     private static let emptyCellsLock = Threading.Lock()
     private static var emptyCells = [UInt64: Int]()
 
@@ -125,7 +128,7 @@ class WebHookRequestHandler {
         }
 
         let trainerLevel = json["trainerlvl"] as? Int ?? (json["trainerLevel"] as? String)?.toInt() ?? 0
-        let trainerXP = json["trainerexp"] as? Int ?? 0
+        var trainerXP = json["trainerexp"] as? Int ?? 0
         let username = json["username"] as? String
         let controller = uuid != nil ? InstanceController.global.getInstanceController(deviceUUID: uuid!) : nil
         let isEvent = controller?.isEvent ?? false
@@ -141,10 +144,6 @@ class WebHookRequestHandler {
                     levelCacheLock.unlock()
                 } catch {}
             }
-        }
-
-        if username != nil && trainerXP > 0 && trainerLevel > 0 {
-            InstanceController.global.gotPlayerInfo(username: username!, level: trainerLevel, xp: trainerXP)
         }
 
         guard let contents = json["contents"] as? [[String: Any]] ??
@@ -174,6 +173,7 @@ class WebHookRequestHandler {
         var fortSearch = [FortSearchOutProto]()
         var encounters = [EncounterOutProto]()
         var playerdatas = [GetPlayerOutProto]()
+        var holodatas = [GetHoloholoInventoryOutProto]()
         var cells = [UInt64]()
 
         var isEmtpyGMO = true
@@ -217,6 +217,12 @@ class WebHookRequestHandler {
                     playerdatas.append(gpr)
                 } else {
                     Log.info(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Malformed GetPlayerResponse")
+                }
+            } else if method == 4 {
+                if let hir = try? GetHoloholoInventoryOutProto(serializedData: data) {
+                    holodatas.append(hir)
+                } else {
+                    Log.info(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Malformed GetHoloInventoryResponse")
                 }
             } else if method == 101 {
                 if let fsr = try? FortSearchOutProto(serializedData: data) {
@@ -478,6 +484,40 @@ class WebHookRequestHandler {
                 }
                 Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Player Detail parsed in " +
                                    "\(String(format: "%.3f", Date().timeIntervalSince(start)))s")
+            }
+
+            if !holodatas.isEmpty && username != nil {
+                let start = Date()
+                for holodata in holodatas {
+                    let items = holodata.inventoryDelta.inventoryItems
+                    for item in items {
+                        let playerstats = item.inventoryItemData.playerStats
+                        trainerXP = Int(playerstats.experience) > 0 ? Int(playerstats.experience) : trainerXP
+                    }
+                }
+                Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Holo Inventory parsed in " +
+                "\(String(format: "%.3f", Date().timeIntervalSince(start)))s")
+
+                if trainerXP > 0 && InstanceController.global.shouldStoreExp(deviceUUID: uuid ?? "") {
+                    let mysqlStart = Date()
+                    expCacheLock.lock()
+                    let oldExp = expCache[username!]
+                    expCacheLock.unlock()
+                    if trainerXP != oldExp {
+                        do {
+                            try Account.setTotalExp(mysql: mysql, username: username!, totalExp: trainerXP)
+                            expCacheLock.lock()
+                            expCache[username!] = trainerXP
+                            expCacheLock.unlock()
+                        } catch {}
+                    }
+                    Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Updated total_exp in db " +
+                    "\(String(format: "%.3f", Date().timeIntervalSince(mysqlStart)))s")
+                }
+            }
+
+            if username != nil && trainerXP > 0 && trainerLevel > 0 {
+                InstanceController.global.gotPlayerInfo(username: username!, level: trainerLevel, xp: trainerXP)
             }
 
             guard InstanceController.global.shouldStoreData(deviceUUID: uuid ?? "") else {

--- a/resources/migrations/70.sql
+++ b/resources/migrations/70.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `account`
+ADD COLUMN `total_exp` int unsigned;

--- a/resources/webroot/dashboard_instance_add.mustache
+++ b/resources/webroot/dashboard_instance_add.mustache
@@ -12,6 +12,7 @@
                 $('.delay_logout_text').addClass('d-none');
                 $('.radius_text').addClass('d-none');
                 $('.store_data_text').addClass('d-none');
+                $('.store_exp_text').addClass('d-none');
             } else if ($(this).val() === 'auto_quest') {
                 $('.pokemon_ids_text').addClass('d-none');
                 $('.scatter_pokemon_ids_text').addClass('d-none');
@@ -21,6 +22,7 @@
                 $('.delay_logout_text').removeClass('d-none');
                 $('.radius_text').addClass('d-none');
                 $('.store_data_text').addClass('d-none');
+                $('.store_exp_text').addClass('d-none');
             } else if ($(this).val() === 'leveling') {
                 $('.pokemon_ids_text').addClass('d-none');
                 $('.scatter_pokemon_ids_text').addClass('d-none');
@@ -30,6 +32,7 @@
                 $('.delay_logout_text').addClass('d-none');
                 $('.radius_text').removeClass('d-none');
                 $('.store_data_text').removeClass('d-none');
+                $('.store_exp_text').removeClass('d-none');
             } else {
                 $('.pokemon_ids_text').addClass('d-none');
                 $('.scatter_pokemon_ids_text').addClass('d-none');
@@ -39,6 +42,7 @@
                 $('.delay_logout_text').addClass('d-none');
                 $('.radius_text').addClass('d-none');
                 $('.store_data_text').addClass('d-none');
+                $('.store_exp_text').addClass('d-none');
             }
         });
     })
@@ -113,6 +117,9 @@
             </div>
             <div class="checkbox store_data_text {{^leveling_selected}}d-none{{/leveling_selected}}">
                 <label><input type="checkbox" name="store_data" value="true" {{#store_data}}checked{{/store_data}}> Store Data in Database</label>
+            </div>
+            <div class="checkbox store_exp_text {{^leveling_selected}}d-none{{/leveling_selected}}">
+                <label><input type="checkbox" name="store_exp" value="true" {{#store_exp}}checked{{/store_exp}}> Store Exp in Database</label>
             </div>
             <div class="form-group">
                 Account Group

--- a/resources/webroot/dashboard_instance_edit.mustache
+++ b/resources/webroot/dashboard_instance_edit.mustache
@@ -12,6 +12,7 @@
                 $('.delay_logout_text').addClass('d-none');
                 $('.radius_text').addClass('d-none');
                 $('.store_data_text').addClass('d-none');
+                $('.store_exp_text').addClass('d-none');
             } else if ($(this).val() === 'auto_quest') {
                 $('.pokemon_ids_text').addClass('d-none');
                 $('.scatter_pokemon_ids_text').addClass('d-none');
@@ -21,6 +22,7 @@
                 $('.delay_logout_text').removeClass('d-none');
                 $('.radius_text').addClass('d-none');
                 $('.store_data_text').addClass('d-none');
+                $('.store_exp_text').addClass('d-none');
             } else if ($(this).val() === 'leveling') {
                 $('.pokemon_ids_text').addClass('d-none');
                 $('.scatter_pokemon_ids_text').addClass('d-none');
@@ -30,6 +32,7 @@
                 $('.delay_logout_text').addClass('d-none');
                 $('.radius_text').removeClass('d-none');
                 $('.store_data_text').removeClass('d-none');
+                $('.store_exp_text').removeClass('d-none');
             } else {
                 $('.pokemon_ids_text').addClass('d-none');
                 $('.scatter_pokemon_ids_text').addClass('d-none');
@@ -39,6 +42,7 @@
                 $('.delay_logout_text').addClass('d-none');
                 $('.radius_text').addClass('d-none');
                 $('.store_data_text').addClass('d-none');
+                $('.store_exp_text').addClass('d-none');
             }
         });
     })
@@ -113,6 +117,9 @@
             </div>
             <div class="checkbox store_data_text {{^leveling_selected}}d-none{{/leveling_selected}}">
                 <label><input type="checkbox" name="store_data" value="true" {{#store_data}}checked{{/store_data}}> Store Data in Database</label>
+            </div>
+            <div class="checkbox store_exp_text {{^leveling_selected}}d-none{{/leveling_selected}}">
+                <label><input type="checkbox" name="store_exp" value="true" {{#store_exp}}checked{{/store_exp}}> Store Exp in Database</label>
             </div>
             <div class="form-group">
                 Account Group


### PR DESCRIPTION
Extended version of https://github.com/RealDeviceMap/RealDeviceMap/pull/146 with ability to save total experience in database based on switch.

## Description
Added new switch for leveling instance to chose whatever we want to store total experience in database or not.

## Motivation and Context
Useful to track progress in monitoring tools.

## How Has This Been Tested?
Testing on own production. No problems from 4 days~

- ON/OFF database saving switch works okay and is not changeable on other instances than "Leveling" where it stays OFF.
- Query update times are low enough
- Status on instance page is updated correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix anyissues they point out. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
