### PR TITLE
Show Pokestop when Quest is active and normal pokestops deactivated

### DIFF
--- a/Sources/RealDeviceMap/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMap/Modell/Pokestop.swift
@@ -689,7 +689,12 @@ class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
                                  "UNIX_TIMESTAMP())"
             let hasNoInvasionSQL = "(incident_expire_timestamp IS NULL OR incident_expire_timestamp < UNIX_TIMESTAMP())"
 
-            excludePokestopSQL = "AND ("
+            excludePokestopSQL = ""
+            if showQuests {
+                excludePokestopSQL += "OR ("
+            } else {
+                excludePokestopSQL += "AND ("
+            }
             if excludeNormal && excludeInvasion {
                 excludePokestopSQL += "(\(hasLureSQL) AND \(hasNoInvasionSQL))"
             } else if excludeNormal && !excludeInvasion {


### PR DESCRIPTION
## Description
Changed SQL query from AND to OR connection between Pokestop Filter and Quest Filter.

## Motivation and Context
A user wants to see pokestops with certain quests and all Team Rocket Invasions. But all normal Pokestops should not be visible. Then RDM  won't show certain Quests when no Grunt is active on the Stop.

## How Has This Been Tested?
Please test. Don't know if it is enough to change the sql-query.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix anyissues they point out. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
