### PR TITLE
Pokémon size doesn't refer static to size literals

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
@@ -75,6 +75,8 @@ public class PVPStatsManager {
                 let pokemonInfo = data["pokemonSettings"] as? [String: Any],
                 let pokemonName = pokemonInfo["pokemonId"] as? String,
                 let statsInfo = pokemonInfo["stats"] as? [String: Any],
+                let pokedexHeightM = pokemonInfo["pokedexHeightM"] as? Double,
+                let pokedexWeightKg = pokemonInfo["pokedexWeightKg"] as? Double,
                 let baseStamina = statsInfo["baseStamina"] as? Int,
                 let baseAttack = statsInfo["baseAttack"] as? Int,
                 let baseDefense = statsInfo["baseDefense"] as? Int {
@@ -105,7 +107,8 @@ public class PVPStatsManager {
                     }
                 }
                 let stat = Stats(baseAttack: baseAttack, baseDefense: baseDefense,
-                                  baseStamina: baseStamina, evolutions: evolutions)
+                                  baseStamina: baseStamina, evolutions: evolutions,
+                                  baseHeight: pokedexHeightM, baseWeight: pokedexWeightKg)
                 stats[.init(pokemon: pokemon, form: form)] = stat
             }
         }
@@ -266,11 +269,18 @@ public class PVPStatsManager {
         }
     }
 
+    internal func getStats(
+        pokemon: HoloPokemonId, form: PokemonDisplayProto.Form?
+    ) -> Stats? {
+        return stats[PokemonWithFormAndGender(pokemon: pokemon, form: form)]
+
+    }
+
     private func getPVPValue(iv: IV, level: Double, stats: Stats) -> Int {
-        let mutliplier = (PVPStatsManager.cpMultiplier[level] ?? 0)
-        let attack = Double(iv.attack + stats.baseAttack) * mutliplier
-        let defense = Double(iv.defense + stats.baseDefense) * mutliplier
-        let stamina = Double(iv.stamina + stats.baseStamina) * mutliplier
+        let multiplier = (PVPStatsManager.cpMultiplier[level] ?? 0)
+        let attack = Double(iv.attack + stats.baseAttack) * multiplier
+        let defense = Double(iv.defense + stats.baseDefense) * multiplier
+        let stamina = Double(iv.stamina + stats.baseStamina) * multiplier
         return Int(round(attack * defense * floor(stamina)))
     }
 
@@ -315,6 +325,8 @@ extension PVPStatsManager {
         var baseDefense: Int
         var baseStamina: Int
         var evolutions: [PokemonWithFormAndGender]
+        var baseHeight: Double
+        var baseWeight: Double
     }
 
     struct IV: Equatable {

--- a/Sources/RealDeviceMapLib/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokemon.swift
@@ -52,6 +52,8 @@ public class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStri
             "form": form as Any,
             "cp": cp as Any,
             "level": level as Any,
+            "baseWeight": baseWeight as Any,
+            "baseHeight": baseHeight as Any,
             "weight": weight as Any,
             "size": size as Any,
             "weather": weather as Any,
@@ -149,6 +151,8 @@ public class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStri
     var displayPokemonId: UInt16?
     var pvpRankingsGreatLeague: [[String: Any]]?
     var pvpRankingsUltraLeague: [[String: Any]]?
+    var baseHeight: Double?
+    var baseWeight: Double?
     var isEvent: Bool
 
     var hasChanges = false
@@ -195,6 +199,12 @@ public class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStri
         self.pvpRankingsGreatLeague = pvpRankingsGreatLeague
         self.pvpRankingsUltraLeague = pvpRankingsUltraLeague
         self.isEvent = isEvent
+        let stats = PVPStatsManager.global.getStats(
+            pokemon: HoloPokemonId(rawValue: Int(self.pokemonId)) ?? .missingno,
+            form: PokemonDisplayProto.Form.init(rawValue: Int(self.form ?? 0)) ?? .unset
+        )
+        self.baseHeight = stats?.baseHeight
+        self.baseWeight = stats?.baseWeight
     }
 
     init(mysql: MySQL?=nil, wildPokemon: WildPokemonProto, cellId: UInt64,
@@ -467,13 +477,22 @@ public class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStri
     }
 
     private func setPVP() {
+        let form = PokemonDisplayProto.Form.init(rawValue: Int(self.form ?? 0)) ?? .unset
+        let pokemonID = HoloPokemonId(rawValue: Int(self.pokemonId)) ?? .missingno
+        let gender = PokemonDisplayProto.Gender.init(rawValue: Int(self.gender ?? 0)) ?? .unset
+        if self.baseHeight == nil || self.baseWeight == nil {
+            let stats = PVPStatsManager.global.getStats(
+                pokemon: pokemonID,
+                form: form == .unset ? nil : form
+            )
+            self.baseHeight = stats?.baseHeight
+            self.baseWeight = stats?.baseWeight
+        }
         if Pokemon.noPVP {
             return
         }
-        let form = PokemonDisplayProto.Form.init(rawValue: Int(self.form ?? 0)) ?? .unset
-        let gender = PokemonDisplayProto.Gender.init(rawValue: Int(self.gender ?? 0)) ?? .unset
-        let pokemonID = HoloPokemonId(rawValue: Int(self.pokemonId)) ?? .missingno
         let costume = PokemonDisplayProto.Costume(rawValue: Int(self.costume ?? 0)) ?? .unset
+
         self.pvpRankingsGreatLeague = PVPStatsManager.global.getPVPStatsWithEvolutions(
             pokemon: pokemonID,
             form: form == .unset ? nil : form,

--- a/resources/webroot/index.js.mustache
+++ b/resources/webroot/index.js.mustache
@@ -1994,13 +1994,17 @@ function addPokemon(pokemon, ts) {
     if (oldPokemon.expire_timestamp !== pokemon.expire_timestamp) {
       oldPokemon.expire_timestamp = pokemon.expire_timestamp
     }
-    if (oldPokemon.atk_iv !== pokemon.atk_iv) {
+    if (oldPokemon.atk_iv !== pokemon.atk_iv 
+      || oldPokemon.def_iv !== pokemon.def_iv 
+      || oldPokemon.sta_iv !== pokemon.sta_iv) {
       oldPokemon.atk_iv = pokemon.atk_iv
       oldPokemon.def_iv = pokemon.def_iv
       oldPokemon.sta_iv = pokemon.sta_iv
       oldPokemon.cp = pokemon.cp
       oldPokemon.weight = pokemon.weight
       oldPokemon.size = pokemon.size
+      oldPokemon.baseHeight = pokemon.baseHeight
+      oldPokemon.baseWeight = pokemon.baseWeight
       oldPokemon.move_1 = pokemon.move_1
       oldPokemon.move_2 = pokemon.move_2
       oldPokemon.level = pokemon.level
@@ -2275,8 +2279,12 @@ function getPokemonPopupContent (pokemon) {
   if (pokemon.move_2 !== null) {
     content += '<b>Charge:</b> ' + getMoveName(pokemon.move_2) + '<br>'
   }
-  if (pokemon.height !== null && pokemon.weight !== null) {
-    content += '<b>Size:</b> ' + getSize(pokemon.size) + ' | <b>Weight:</b> ' + Math.round(pokemon.weight) + 'kg<br>'
+  if (pokemon.size !== null && pokemon.weight !== null) {
+    if (pokemon.baseHeight !== null && pokemon.baseWeight !== null) {
+      content += '<b>Weight:</b> ' + (pokemon.weight).toFixed(2) + '-' + getSize(pokemon.weight, pokemon.baseWeight) + ' | <b>Size:</b> ' + (pokemon.size).toFixed(2) + '-' + getSize(pokemon.size, pokemon.baseHeight) + '<br>'
+    } else {
+      content += '<b>Weight:</b> ' + (pokemon.weight).toFixed(2) + 'kg | <b>Size:</b> ' + (pokemon.size).toFixed(2) + 'm<br>'
+    }
   }
   if (pokemon.capture_1 !== null && pokemon.capture_2 !== null && pokemon.capture_3 !== null) {
     content += '<b>Catch Chances:</b><br>'
@@ -4348,12 +4356,20 @@ function getLureIconId (lureId) {
   return 1
 }
 
-function getSize (size) {
-  if (size < 1.5) return 'Tiny'
-  if (size <= 1.75) return 'Small'
-  if (size < 2.25) return 'Normal'
-  if (size <= 2.5) return 'Large'
-  return 'Big'
+function getSize (value, baseValue) {
+  var deviation = value - baseValue
+  var secondDeviation = baseValue*2/8
+  var absoluteDeviation = Math.abs(deviation)
+  if (absoluteDeviation >= secondDeviation) {
+    var signDeviation = Math.sign(deviation)
+    if (signDeviation > 0) {
+      return "XL"
+    } else {
+      return "XS"
+    }
+  } else {
+    return "N"
+  }
 }
 
 function getPokemonIdIconString(pokemonId, pokemonForm, pokemonEvolution) {

--- a/resources/webroot/index.js.mustache
+++ b/resources/webroot/index.js.mustache
@@ -2282,7 +2282,7 @@ function getPokemonPopupContent (pokemon) {
   if (pokemon.size !== null && pokemon.weight !== null) {
     content += '<b>Weight:</b> ' + (pokemon.weight).toFixed(2) + 'kg'
     if (pokemon.baseHeight !== null) {
-      content += ' | <b>Size:</b> ' + (pokemon.size).toFixed(2) + '-' + getSize(pokemon.size, pokemon.baseHeight) + '<br>'
+      content += ' | <b>Size:</b> ' + (pokemon.size).toFixed(2) + getSize(pokemon.size, pokemon.baseHeight) + '<br>'
     } else {
       content += ' | <b>Size:</b> ' + (pokemon.size).toFixed(2) + 'm<br>'
     }
@@ -4364,12 +4364,12 @@ function getSize (value, baseValue) {
   if (absoluteDeviation >= secondDeviation) {
     var signDeviation = Math.sign(deviation)
     if (signDeviation > 0) {
-      return "XL"
+      return " XL"
     } else {
-      return "XS"
+      return " XS"
     }
   } else {
-    return "N"
+    return "m"
   }
 }
 

--- a/resources/webroot/index.js.mustache
+++ b/resources/webroot/index.js.mustache
@@ -2280,10 +2280,11 @@ function getPokemonPopupContent (pokemon) {
     content += '<b>Charge:</b> ' + getMoveName(pokemon.move_2) + '<br>'
   }
   if (pokemon.size !== null && pokemon.weight !== null) {
-    if (pokemon.baseHeight !== null && pokemon.baseWeight !== null) {
-      content += '<b>Weight:</b> ' + (pokemon.weight).toFixed(2) + '-' + getSize(pokemon.weight, pokemon.baseWeight) + ' | <b>Size:</b> ' + (pokemon.size).toFixed(2) + '-' + getSize(pokemon.size, pokemon.baseHeight) + '<br>'
+    content += '<b>Weight:</b> ' + (pokemon.weight).toFixed(2) + 'kg'
+    if (pokemon.baseHeight !== null) {
+      content += ' | <b>Size:</b> ' + (pokemon.size).toFixed(2) + '-' + getSize(pokemon.size, pokemon.baseHeight) + '<br>'
     } else {
-      content += '<b>Weight:</b> ' + (pokemon.weight).toFixed(2) + 'kg | <b>Size:</b> ' + (pokemon.size).toFixed(2) + 'm<br>'
+      content += ' | <b>Size:</b> ' + (pokemon.size).toFixed(2) + 'm<br>'
     }
   }
   if (pokemon.capture_1 !== null && pokemon.capture_2 !== null && pokemon.capture_3 !== null) {


### PR DESCRIPTION
removed method to visualize tiny, small, normal, large, big. Instead return right XL or XS values.

## Description
Pokémon doesn't have a static way to calculate if they are tiny, small, normal, large or big. This calculation should happen separately for each Pokémon species.
This should introduce right XL or XS labels into RDM. It's possible because all Base weight and height for each Pokémon are in GameMaster.json. Actually I use the PVPStatsManager Thread for requesting GameMaster stats for base height and weight.

## Motivation and Context
Not all Roggenrola and Pidgey are small, but with the old behaviour they are always tiny.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
tested successful.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/35898099/132391221-87b7879f-cb12-4337-970e-a7bcdd02c76e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix anyissues they point out. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
