### PR TITLE
fix: set latitude and longitude on encounter

### DIFF
--- a/Sources/RealDeviceMap/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMap/Modell/Pokemon.swift
@@ -353,6 +353,8 @@ class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStringConve
         let costume = UInt8(encounterData.pokemon.pokemon.pokemonDisplay.costume.rawValue)
         let form = UInt16(encounterData.pokemon.pokemon.pokemonDisplay.form.rawValue)
         let gender = UInt8(encounterData.pokemon.pokemon.pokemonDisplay.gender.rawValue)
+        let lat = encounterData.pokemon.latitude
+        let lon = encounterData.pokemon.longitude
 
         if pokemonId != self.pokemonId ||
            cp != self.cp ||
@@ -382,6 +384,8 @@ class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStringConve
         self.costume = costume
         self.form = form
         self.gender = gender
+        self.lat = lat
+        self.lon = lon
 
         self.shiny = encounterData.pokemon.pokemon.pokemonDisplay.shiny
         self.username = username


### PR DESCRIPTION
## Description
Potentially fixes an issue where location of encountered pokemon is overwritten.

## How Has This Been Tested?
Not tested yet

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
