### PR TITLE
Add extra Ditto check

### DIFF
--- a/Sources/RealDeviceMap/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMap/Modell/Pokemon.swift
@@ -1180,7 +1180,8 @@ class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStringConve
              staIv < Pokemon.weatherBoostMinIvStat)
         let isWeatherBoosted = weather > 0
         let isOverLevel = level > 30
-        return (isDisguised && (isUnderLevelBoosted || isUnderIvStatBoosted) && isWeatherBoosted) || (isDisguised && isOverLevel && !isWeatherBoosted)
+        return (isDisguised && (isUnderLevelBoosted || isUnderIvStatBoosted) && isWeatherBoosted) ||
+               (isDisguised && isOverLevel && !isWeatherBoosted)
     }
 
     public static func truncate(mysql: MySQL?=nil) throws {

--- a/Sources/RealDeviceMap/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMap/Modell/Pokemon.swift
@@ -1179,7 +1179,7 @@ class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStringConve
              defIv < Pokemon.weatherBoostMinIvStat ||
              staIv < Pokemon.weatherBoostMinIvStat)
         let isWeatherBoosted = weather > 0
-		let isOverLevel = level > 30
+        let isOverLevel = level > 30
         return (isDisguised && (isUnderLevelBoosted || isUnderIvStatBoosted) && isWeatherBoosted) || (isDisguised && isOverLevel && !isWeatherBoosted)
     }
 

--- a/Sources/RealDeviceMap/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMap/Modell/Pokemon.swift
@@ -1179,7 +1179,8 @@ class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStringConve
              defIv < Pokemon.weatherBoostMinIvStat ||
              staIv < Pokemon.weatherBoostMinIvStat)
         let isWeatherBoosted = weather > 0
-        return isDisguised && (isUnderLevelBoosted || isUnderIvStatBoosted) && isWeatherBoosted
+		let isOverLevel = level > 30
+        return (isDisguised && (isUnderLevelBoosted || isUnderIvStatBoosted) && isWeatherBoosted) || (isDisguised && isOverLevel && !isWeatherBoosted)
     }
 
     public static func truncate(mysql: MySQL?=nil) throws {


### PR DESCRIPTION
added Ditto check where Ditto is boosted and disguise is not

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
In my production db i queried mons that have no weatherboost but are over l30. Then in my test env I send devices to those location and they correctly display as Ditto.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![wb_ditto](https://user-images.githubusercontent.com/43513167/132091143-e614a78d-835d-4452-a4dd-8957cb68a423.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix anyissues they point out. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
