### PR TITLE
fix query to count/delete convertible pokestops

### DIFF
--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -1319,7 +1319,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         let sql = """
         SELECT id
         FROM `pokestop`
-        WHERE id IN (SELECT id FROM `gym`)
+        WHERE id IN (SELECT id FROM `gym` where deleted = 0)
         """
 
         let mysqlStmt = MySQLStmt(mysql)
@@ -1366,7 +1366,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
 
         let sql = """
         DELETE FROM `pokestop`
-        WHERE id IN (SELECT id FROM `gym`)
+        WHERE id IN (SELECT id FROM `gym` where deleted = 0)
         """
 
         let mysqlStmt = MySQLStmt(mysql)

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -1319,7 +1319,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         let sql = """
         SELECT id
         FROM `pokestop`
-        WHERE id IN (SELECT id FROM `gym` where deleted = 0)
+        WHERE id IN (SELECT id FROM `gym` WHERE deleted = 0)
         """
 
         let mysqlStmt = MySQLStmt(mysql)
@@ -1366,7 +1366,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
 
         let sql = """
         DELETE FROM `pokestop`
-        WHERE id IN (SELECT id FROM `gym` where deleted = 0)
+        WHERE id IN (SELECT id FROM `gym` WHERE deleted = 0)
         """
 
         let mysqlStmt = MySQLStmt(mysql)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
if the gym is demoted from gym to pokestop -> gym deleted is set to 1 and `Pokestop.getConvertiblePokestopsCount()` will show wrong count.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix anyissues they point out. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
