### PR TITLE
Add `skip_instance_status` to `get_data` API endpoint

### DIFF
--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -126,6 +126,7 @@ public class ApiRequestHandler {
         let showDevices = request.param(name: "show_devices")?.toBool() ?? false
         let showActiveDevices = request.param(name: "show_active_devices")?.toBool() ?? false
         let showInstances = request.param(name: "show_instances")?.toBool() ?? false
+        let skipInstanceStatus = request.param(name: "skip_instance_status")?.toBool() ?? false
         let showDeviceGroups = request.param(name: "show_devicegroups")?.toBool() ?? false
         let showUsers = request.param(name: "show_users")?.toBool() ?? false
         let showGroups = request.param(name: "show_groups")?.toBool() ?? false
@@ -1641,7 +1642,9 @@ public class ApiRequestHandler {
                         instanceData["type"] = "Leveling"
                     }
 
-                    if formatted {
+                    if skipInstanceStatus {
+                        instanceData["status"] = nil
+                    } else if formatted {
                         let status = InstanceController.global.getInstanceStatus(
                             mysql: mysql,
                             instance: instance,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `skip_instance_status` parameter for `/get_data` API endpoint to disable `status` pull for instances query.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`/api/get_data?show_instances=true` - this call is taking ~4000-8000ms! Discord limits component processing time to 3000ms.

`/api/get_data?show_instances=true&skip_instance_status=true` - proposed change would allow pulling all data without `status` field.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using UI and API calls. All fine

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix anyissues they point out. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
