### PR TITLE
fix api get_data assignment-groups

### DIFF
--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -1783,9 +1783,9 @@ public class ApiRequestHandler {
 
                     var assignmentGroupData = [String: Any]()
                     assignmentGroupData["name"] = assignmentGroup.name
+                    assignmentGroupData["assignments"] = assignmentsInGroupDevices.joined(separator: ", ")
 
                     if formatted {
-                        assignmentGroupData["assignments"] = assignmentsInGroupDevices.joined(separator: ", ")
                         let id = assignmentGroup.name.encodeUrl()!
                         assignmentGroupData["buttons"] = "<div class=\"btn-group\" role=\"group\"><a " +
                             "href=\"/dashboard/assignmentgroup/start/\(id)\" " +
@@ -1801,8 +1801,6 @@ public class ApiRequestHandler {
                             "confirm('Are you sure you want to delete this assignment " +
                             "group? This action is irreversible and cannot be " +
                             "undone without backups.')\">Delete</a></div>"
-                    } else {
-                        assignmentGroupData["assignments"] = assignments
                     }
 
                     jsonArray.append(assignmentGroupData)


### PR DESCRIPTION
assignment can not be converted to JSON

`Could not cast value of type 'RealDeviceMapLib.Assignment' (0x557abe482930) to 'PerfectLib.JSONConvertible' (0x7f00f720ab00).`

Also wrong variable was assigned to assignmentGroupData - all assignments of instance, not only assignments of assignment-group