### PR TITLE
fix quest database table

### DIFF
--- a/resources/migrations/77.sql
+++ b/resources/migrations/77.sql
@@ -1,0 +1,7 @@
+alter table pokestop
+    modify column `quest_pokemon_id` smallint unsigned GENERATED ALWAYS AS (JSON_EXTRACT(JSON_EXTRACT(quest_rewards, '$[*].info.pokemon_id'), '$[0]'));
+
+alter table pokestop
+    add column `quest_reward_amount` smallint unsigned GENERATED ALWAYS AS (JSON_EXTRACT(JSON_EXTRACT(quest_rewards, '$[*].info.amount'), '$[0]')) AFTER `quest_item_id`,
+    add column `alternative_quest_reward_amount` smallint unsigned GENERATED ALWAYS AS (JSON_EXTRACT(JSON_EXTRACT(alternative_quest_rewards, '$[*].info.amount'), '$[0]')) AFTER `alternative_quest_item_id`;
+


### PR DESCRIPTION
`quest_pokemon_id` was only filled automatically when `quest_reward_type = 7`, but that information is also interesting for candy and mega-energy. for alternative_quest the auto generated column was extracted everytime :)

with stardust, mega energy and candy it's also interesting to store amount separate, to improve sql queries (no need to json_extract)