### PR TITLE
fix getPerms for handleSetData

### DIFF
--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -32,7 +32,7 @@ public class ApiRequestHandler {
     public static var start: Date = Date(timeIntervalSince1970: 0)
 
     // swiftlint:disable:next cyclomatic_complexity
-    private static func getPerms(request: HTTPRequest, response: HTTPResponse) -> [Group.Perm]? {
+    private static func getPerms(request: HTTPRequest, response: HTTPResponse, target: String) -> [Group.Perm]? {
         let tmp = WebRequestHandler.getPerms(request: request, fromCache: true)
         let perms = tmp.perms
         let username = tmp.username
@@ -75,7 +75,11 @@ public class ApiRequestHandler {
                             request.session?.data["perms"] = Group.Perm.permsToNumber(perms: user.group!.perms)
                         }
                         sessionDriver.save(session: request.session!)
-                        handleGetData(request: request, response: response)
+                        if target == "get_data" {
+                            handleGetData(request: request, response: response)
+                        } else if target == "set_data" {
+                            handleSetData(request: request, response: response)
+                        }
                         return nil
                     }
                 }
@@ -87,7 +91,7 @@ public class ApiRequestHandler {
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     private static func handleGetData(request: HTTPRequest, response: HTTPResponse) {
-        guard let perms = getPerms(request: request, response: response) else {
+        guard let perms = getPerms(request: request, response: response, target: "get_data") else {
             return
         }
 
@@ -2177,7 +2181,7 @@ public class ApiRequestHandler {
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     private static func handleSetData(request: HTTPRequest, response: HTTPResponse) {
 
-        guard let perms = getPerms(request: request, response: response) else {
+        guard let perms = getPerms(request: request, response: response, target: "set_data") else {
             return
         }
 

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -32,7 +32,8 @@ public class ApiRequestHandler {
     public static var start: Date = Date(timeIntervalSince1970: 0)
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
-    private static func getPerms(request: HTTPRequest, response: HTTPResponse, target: String) -> [Group.Perm]? {
+    private static func getPerms(request: HTTPRequest, response: HTTPResponse, route: WebServer.APIPage)
+	-> [Group.Perm]? {
         let tmp = WebRequestHandler.getPerms(request: request, fromCache: true)
         let perms = tmp.perms
         let username = tmp.username
@@ -75,9 +76,10 @@ public class ApiRequestHandler {
                             request.session?.data["perms"] = Group.Perm.permsToNumber(perms: user.group!.perms)
                         }
                         sessionDriver.save(session: request.session!)
-                        if target == "get_data" {
+                        switch route {
+                        case .getData:
                             handleGetData(request: request, response: response)
-                        } else if target == "set_data" {
+                        case .setData:
                             handleSetData(request: request, response: response)
                         }
                         return nil
@@ -91,7 +93,7 @@ public class ApiRequestHandler {
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     private static func handleGetData(request: HTTPRequest, response: HTTPResponse) {
-        guard let perms = getPerms(request: request, response: response, target: "get_data") else {
+        guard let perms = getPerms(request: request, response: response, route: WebServer.APIPage.getData) else {
             return
         }
 
@@ -2181,7 +2183,7 @@ public class ApiRequestHandler {
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     private static func handleSetData(request: HTTPRequest, response: HTTPResponse) {
 
-        guard let perms = getPerms(request: request, response: response, target: "set_data") else {
+        guard let perms = getPerms(request: request, response: response, route: WebServer.APIPage.setData) else {
             return
         }
 

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -31,7 +31,7 @@ public class ApiRequestHandler {
 
     public static var start: Date = Date(timeIntervalSince1970: 0)
 
-    // swiftlint:disable:next cyclomatic_complexity
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     private static func getPerms(request: HTTPRequest, response: HTTPResponse, target: String) -> [Group.Perm]? {
         let tmp = WebRequestHandler.getPerms(request: request, fromCache: true)
         let perms = tmp.perms


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix `getPerms` method for `handleSetData` usage.
`getPerms` is redirecting at the end of the method to method it was called from. Before proposed change, it was redirecting authorized by Basic Auth user only to `handleGetData` method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Wasn't

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix anyissues they point out. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
