### PR TITLE
docker build - update mysql-apt-config

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,12 +12,12 @@ jobs:
       run: export DEBIAN_FRONTEND=noninteractive &&
            sudo apt-get -y update &&
            sudo apt-get install -y libssl-dev libcurl4-openssl-dev uuid-dev imagemagick lsb-release &&
-           wget http://repo.mysql.com/mysql-apt-config_0.8.16-1_all.deb &&
+           wget http://repo.mysql.com/mysql-apt-config_0.8.22-1_all.deb &&
            echo mysql-apt-config    mysql-apt-config/repo-codename  select  bionic | sudo debconf-set-selections &&
            echo mysql-apt-config    mysql-apt-config/repo-distro    select  ubuntu | sudo debconf-set-selections &&
            echo mysql-apt-config    mysql-apt-config/select-server  select  mysql-5.7 | sudo debconf-set-selections &&
            echo mysql-apt-config    mysql-apt-config/select-product select  Ok | sudo debconf-set-selections &&
-           sudo dpkg -i mysql-apt-config_0.8.16-1_all.deb &&
+           sudo dpkg -i mysql-apt-config_0.8.22-1_all.deb &&
            sudo apt-get purge -y mysql-client mysql-common mysql-server &&
            sudo apt-get autoremove -y &&
            sudo apt-get -y update &&

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,12 @@ RUN apt-get -y update && apt-get install -y wget
 RUN export DEBIAN_FRONTEND=noninteractive && \
 	apt-get -y update && \
 	apt-get install -y lsb-release && \
-	wget http://repo.mysql.com/mysql-apt-config_0.8.16-1_all.deb && \
+	wget http://repo.mysql.com/mysql-apt-config_0.8.22-1_all.deb && \
 	echo mysql-apt-config    mysql-apt-config/repo-codename  select  bionic | debconf-set-selections && \
 	echo mysql-apt-config    mysql-apt-config/repo-distro    select  ubuntu | debconf-set-selections && \
 	echo mysql-apt-config    mysql-apt-config/select-server  select  mysql-5.7 | debconf-set-selections && \
 	echo mysql-apt-config    mysql-apt-config/select-product select  Ok | debconf-set-selections && \
-	dpkg -i mysql-apt-config_0.8.16-1_all.deb && \
+	dpkg -i mysql-apt-config_0.8.22-1_all.deb && \
 	apt-get -y update && \
 	apt-get install -y -f mysql-client=5.7* libmysqlclient-dev=5.7* && \
 	sed -i -e 's/-fabi-version=2 -fno-omit-frame-pointer//g' /usr/lib/x86_64-linux-gnu/pkgconfig/mysqlclient.pc
@@ -73,12 +73,12 @@ RUN apt-get -y update && apt-get install -y wget
 RUN export DEBIAN_FRONTEND=noninteractive && \
 	apt-get -y update && \
 	apt-get install -y lsb-release && \
-	wget http://repo.mysql.com/mysql-apt-config_0.8.16-1_all.deb && \
+	wget http://repo.mysql.com/mysql-apt-config_0.8.22-1_all.deb && \
 	echo mysql-apt-config    mysql-apt-config/repo-codename  select  bionic | debconf-set-selections && \
 	echo mysql-apt-config    mysql-apt-config/repo-distro    select  ubuntu | debconf-set-selections && \
 	echo mysql-apt-config    mysql-apt-config/select-server  select  mysql-5.7 | debconf-set-selections && \
 	echo mysql-apt-config    mysql-apt-config/select-product select  Ok | debconf-set-selections && \
-	dpkg -i mysql-apt-config_0.8.16-1_all.deb && \
+	dpkg -i mysql-apt-config_0.8.22-1_all.deb && \
 	apt-get -y update && \
 	apt-get install -y -f mysql-client=5.7* libmysqlclient-dev=5.7* && \
 	sed -i -e 's/-fabi-version=2 -fno-omit-frame-pointer//g' /usr/lib/x86_64-linux-gnu/pkgconfig/mysqlclient.pc


### PR DESCRIPTION
used version `mysql-apt-config` is not "supported" anymore (invalid signature for repository to fetch). need to update to latest version

this is only relevant for new PR builds