### PR TITLE
Some small improvements

### DIFF
--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -92,6 +92,7 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
                 "latitude": lat,
                 "longitude": lon,
                 "team": teamId ?? 0,
+                "guard_pokemon_id": guardPokemonId ?? 0,
                 "slots_available": availableSlots ?? 6,
                 "ex_raid_eligible": exRaidEligible ?? 0,
                 "in_battle": inBattle ?? false,

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -860,7 +860,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
                 if !excludedTypes.contains(6) { // mega energy reward type = 12
                     sqlExcludeCreate += " OR \(questRewardTypeSql) = 12"
                 }
-                excludeQuestPokemonSQL = sqlExcludeCreate
+                excludeQuestPokemonSQL = "("+sqlExcludeCreate+")"
             }
 
             if excludedItems.isEmpty {

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -853,14 +853,14 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
                 for _ in 1..<excludedPokemon.count {
                     sqlExcludeCreate += "?, "
                 }
-                sqlExcludeCreate += "?))"
+                sqlExcludeCreate += "?)"
                 if !excludedTypes.contains(3) { // candy reward type = 4
                     sqlExcludeCreate += " OR \(questRewardTypeSql) = 4"
                 }
                 if !excludedTypes.contains(6) { // mega energy reward type = 12
                     sqlExcludeCreate += " OR \(questRewardTypeSql) = 12"
                 }
-                excludeQuestPokemonSQL = "("+sqlExcludeCreate+")"
+                excludeQuestPokemonSQL = sqlExcludeCreate+")"
             }
 
             if excludedItems.isEmpty {

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -854,6 +854,12 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
                     sqlExcludeCreate += "?, "
                 }
                 sqlExcludeCreate += "?))"
+                if !excludedTypes.contains(3) { // candy reward type = 4
+                    sqlExcludeCreate += " OR \(questRewardTypeSql) = 4"
+                }
+                if !excludedTypes.contains(6) { // mega energy reward type = 12
+                    sqlExcludeCreate += " OR \(questRewardTypeSql) = 12"
+                }
                 excludeQuestPokemonSQL = sqlExcludeCreate
             }
 


### PR DESCRIPTION
- add guard_pokemon_id to gym_details webhook (#226)
- improve filter logic for candy and mega-energy (does only affect RDM frontend) - no need for enable Ampharos pokemon in quest filter to see mega-energy of it