### PR TITLE
Fix dual-quest TimedMap

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/TimedMap.swift
+++ b/Sources/RealDeviceMapLib/Misc/TimedMap.swift
@@ -14,14 +14,14 @@ public class TimedMap<K: Hashable, V> {
     public func setValue(key: K, value: V, time: UInt64) {
         mapLock.lock()
         if map[key] != nil {
-            let lastIndex = map[key]?.lastIndex {value in value.time >= time}
+            let lastIndex = map[key]!.lastIndex {value in value.time >= time}
             if lastIndex != nil {
                 map[key]!.insert((time: time, value: value), at: lastIndex!)
             } else {
                 map[key]!.append((time: time, value: value))
             }
             if map[key]!.count > length {
-                _ = map[key]!.dropFirst()
+                _ = map[key]!.removeFirst()
             }
         } else {
             map[key] = [(time: time, value: value)]

--- a/Sources/RealDeviceMapLib/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokemon.swift
@@ -855,7 +855,8 @@ public class Pokemon: JSONConvertibleObject, WebHookEvent, Equatable, CustomStri
             if mysqlStmt.errorCode() == 1062 {
                 Log.debug(message: "[POKEMON] Duplicated key. Skipping...")
             } else {
-                Log.error(message: "[POKEMON] Failed to execute query 'save'. (\(mysqlStmt.errorMessage()))")
+                Log.error(message: "[POKEMON] Failed to execute query '\(oldPokemon != nil ? "update" : "insert")'. " +
+                                    "(\(mysqlStmt.errorMessage()))")
             }
             throw DBController.DBError()
         }


### PR DESCRIPTION
TimedMap for fix DUAL-Quest for GC does not reduce size properly, it only increase size (`dropFirst` does only return a modified list but does not modify the list itself), this can cause RAM usage increase with a lots of devices