### PR TITLE
Support next scan API for Circle InstanceController

### DIFF
--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2303,12 +2303,14 @@ public class ApiRequestHandler {
                 response.respondWithError(status: .internalServerError)
             }
         } else if scanNext && perms.contains(.admin), let name = instanceName, let coords = coords {
-            Log.info(message: "[ApiRequestHandler] API request to scan next coordinates at \(name)")
+            Log.info(message: "[ApiRequestHandler] API request to scan next coordinates with instance '\(name)'")
             guard let instance = InstanceController.global.getInstanceController(instanceName: name)
                 as? CircleInstanceController else {
+                    Log.error(message: "[ApiRequestHandler] Instance '\(name)' not found")
                     return response.respondWithError(status: .custom(code: 404, message: "Instance not found"))
             }
             if InstanceController.global.getDeviceUUIDsInInstance(instanceName: name).isEmpty {
+                Log.error(message: "[ApiRequestHandler] Instance '\(name)' without devices")
                 return response.respondWithError(status: .custom(code: 416, message: "Instance without devices"))
             }
             if !coords.isEmpty {

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2313,10 +2313,19 @@ public class ApiRequestHandler {
                 Log.error(message: "[ApiRequestHandler] Instance '\(name)' without devices")
                 return response.respondWithError(status: .custom(code: 416, message: "Instance without devices"))
             }
+            var size = 0
             if !coords.isEmpty {
-                instance.addToNextCoords(coords: coords)
+                size = instance.addToNextCoords(coords: coords)
             }
-            response.respondWithOk()
+            do {
+                try response.respondWithData(data: [
+                    "action": "next_scan",
+                    "queue_size": size
+                ])
+            } catch {
+                response.respondWithError(status: .internalServerError)
+            }
+
         } else {
             response.respondWithError(status: .badRequest)
         }

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2172,6 +2172,8 @@ public class ApiRequestHandler {
             }
         }
 
+        print("[TMP] scanNext call: scan_next=\(scanNext), queue_size=\(queueSize) " +
+            "instance=\(instance != nil ? instance! : "unknown"), perms=\(perms.contains(.admin))")
         if scanNext && queueSize && perms.contains(.admin), let name = instance {
             guard let instance = InstanceController.global.getInstanceController(instanceName: name.decodeUrl() ?? "")
                 as? CircleInstanceController else {

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2315,7 +2315,7 @@ public class ApiRequestHandler {
             } catch {
                 response.respondWithError(status: .internalServerError)
             }
-        } else if scanNext && perms.contains(.admin), let name = instanceName, let coords = coords {
+        } else if scanNext && perms.contains(.admin), let name = instance, let coords = coords {
             Log.info(message: "[ApiRequestHandler] API request to scan next coordinates with instance '\(name)'")
             guard let instance = InstanceController.global.getInstanceController(instanceName: name.decodeUrl() ?? "")
                 as? CircleInstanceController else {

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2217,7 +2217,6 @@ public class ApiRequestHandler {
         let assignmentGroupName = request.param(name: "assignmentgroup_name")
 
         let scanNext = request.param(name: "scan_next")?.toBool() ?? false
-        let queueSize = request.param(name: "queue_size")?.toBool() ?? false
         let coords = try? jsonDecoder.decode([Coord].self,
             from: request.param(name: "coords")?.data(using: .utf8) ?? Data())
 

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2172,8 +2172,6 @@ public class ApiRequestHandler {
             }
         }
 
-        print("[TMP] scanNext call: scan_next=\(scanNext), queue_size=\(queueSize) " +
-            "instance=\(instance != nil ? instance! : "unknown"), perms=\(perms.contains(.admin))")
         if scanNext && queueSize && perms.contains(.admin), let name = instance {
             guard let instance = InstanceController.global.getInstanceController(instanceName: name.decodeUrl() ?? "")
                 as? CircleInstanceController else {

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2184,9 +2184,12 @@ public class ApiRequestHandler {
             data["size"] = size
         }
 
-        data["timestamp"] = Int(Date().timeIntervalSince1970)
-
         do {
+            if data.isEmpty {
+                response.respondWithError(status: .badRequest)
+                return
+            }
+            data["timestamp"] = Int(Date().timeIntervalSince1970)
             try response.respondWithData(data: data)
         } catch {
             response.respondWithError(status: .internalServerError)

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2332,7 +2332,8 @@ public class ApiRequestHandler {
             do {
                 try response.respondWithData(data: [
                     "action": "next_scan",
-                    "queue_size": size
+                    "size": size,
+                    "timestamp": Int(Date().timeIntervalSince1970)
                 ])
             } catch {
                 response.respondWithError(status: .internalServerError)

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
@@ -237,7 +237,7 @@ class CircleInstanceController: InstanceControllerProto {
 
     func addToNextCoords(coords: [Coord]) {
         let message = coords.map { "\($0.lat),\($0.lon)"}.jsonEncodeForceTry() ?? ""
-        Log.info(message: "[CircleInstanceController] Added next coords to scan: \(message)")
+        Log.info(message: "[CircleInstanceController] Added next coordinates to scan: \(message)")
         lock.lock()
         for coord in coords {
             scanNextCoords.append(coord)

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
@@ -246,6 +246,6 @@ class CircleInstanceController: InstanceControllerProto {
     }
 
     func getNextCoordsSize() -> Int {
-        scanNextCoords.count
+        lock.doWithLock { scanNextCoords.count }
     }
 }

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
@@ -101,15 +101,14 @@ class CircleInstanceController: InstanceControllerProto {
         var currentIndex = 0
         var currentUuidIndex = 0
         var currentCoord = coords[currentIndex]
+        lock.lock()
         if !scanNextCoords.isEmpty {
-            lock.lock()
             currentCoord = scanNextCoords.removeFirst()
             lock.unlock()
             return ["action": "scan_pokemon", "lat": currentCoord.lat, "lon": currentCoord.lon,
                     "min_level": minLevel, "max_level": maxLevel]
         }
         if type == .smartPokemon {
-            lock.lock()
             currentUuidIndex = currentUuidIndexes[uuid] ?? Int.random(in: 0..<coords.count)
             currentUuidIndexes[uuid] = currentUuidIndex
             currentUuidSeenTime[uuid] = Date()
@@ -148,7 +147,6 @@ class CircleInstanceController: InstanceControllerProto {
             return ["action": "scan_pokemon", "lat": currentCoord.lat, "lon": currentCoord.lon,
                     "min_level": minLevel, "max_level": maxLevel]
         } else {
-            lock.lock()
             currentIndex = self.lastIndex
             if lastIndex + 1 == coords.count {
                 lastLastCompletedTime = lastCompletedTime

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
@@ -233,13 +233,15 @@ class CircleInstanceController: InstanceControllerProto {
         }
     }
 
-    func addToNextCoords(coords: [Coord]) {
+    func addToNextCoords(coords: [Coord]) -> Int {
         let message = coords.map { "\($0.lat),\($0.lon)"}.jsonEncodeForceTry() ?? ""
         Log.info(message: "[CircleInstanceController] Added next coordinates to scan: \(message)")
         lock.lock()
         for coord in coords {
             scanNextCoords.append(coord)
         }
+        let size = scanNextCoords.count
         lock.unlock()
+        return size
     }
 }

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
@@ -236,7 +236,8 @@ class CircleInstanceController: InstanceControllerProto {
     }
 
     func addToNextCoords(coords: [Coord]) {
-        print("[TMP] add coords to scan next")
+        let message = coords.map( { "\($0.lat),\($0.lon)"}).jsonEncodeForceTry() ?? ""
+        Log.info(message: "[CircleInstanceController] Added next coords to scan: \(message)")
         lock.lock()
         for coord in coords {
             scanNextCoords.append(coord)

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
@@ -236,7 +236,7 @@ class CircleInstanceController: InstanceControllerProto {
     }
 
     func addToNextCoords(coords: [Coord]) {
-        let message = coords.map( { "\($0.lat),\($0.lon)"}).jsonEncodeForceTry() ?? ""
+        let message = coords.map { "\($0.lat),\($0.lon)"}.jsonEncodeForceTry() ?? ""
         Log.info(message: "[CircleInstanceController] Added next coords to scan: \(message)")
         lock.lock()
         for coord in coords {

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
@@ -244,4 +244,8 @@ class CircleInstanceController: InstanceControllerProto {
         lock.unlock()
         return size
     }
+
+    func getNextCoordsSize() -> Int {
+        scanNextCoords.count
+    }
 }

--- a/Sources/RealDeviceMapLib/Modell/Coord.swift
+++ b/Sources/RealDeviceMapLib/Modell/Coord.swift
@@ -11,7 +11,7 @@ import Foundation
 import PerfectLib
 import Turf
 
-public class Coord: JSONConvertibleObject, Hashable {
+public class Coord: JSONConvertibleObject, Hashable, Codable {
 
     var lat: Double
     var lon: Double


### PR DESCRIPTION
API call for sending next scan coordinates.
existing route (if exists) will be paused, list of next coordinates will be scanned and existing Route will be continued afterwards.

Example:

> params: {
>      scan_next: true,
>      instance: 'ScanTest',
>      coords: '[{"lat":"46.87287","lon":"22.30138"}]'
>  }

`api/set_data?scan_next=true&instance=ScanTest&coords='[{"lat":46.87287,"lon":22.30138}]'`

queue-size:
`api/get_data?scan_next=true&queue_size=true&instance=ScanTest`