### PR TITLE
filter improvements power-up

### DIFF
--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -242,17 +242,24 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
         self.exRaidEligible = fortData.isExRaidEligible
         self.inBattle = fortData.isInBattle
         self.arScanEligible = fortData.isArScanEligible
+        let now = UInt32(Date().timeIntervalSince1970)
+        let powerUpRemaining = UInt32(fortData.powerUpRemainingUntilMs / 1000)
         self.powerUpPoints = UInt32(fortData.locationPoints)
         if fortData.locationPoints < 50 {
             self.powerUpLevel = 0
-        } else if fortData.locationPoints < 100 {
+        } else if fortData.locationPoints < 100 && powerUpRemaining > now {
             self.powerUpLevel = 1
-        } else if fortData.locationPoints < 150 {
+            self.powerUpEndTimestamp = powerUpRemaining
+        } else if fortData.locationPoints < 150 && powerUpRemaining > now {
             self.powerUpLevel = 2
-        } else {
+            self.powerUpEndTimestamp = powerUpRemaining
+        } else if powerUpRemaining > now {
             self.powerUpLevel = 3
+            self.powerUpEndTimestamp = powerUpRemaining
+        } else {
+            self.powerUpLevel = 0
         }
-        self.powerUpEndTimestamp = UInt32(fortData.powerUpRemainingUntilMs / 1000)
+
         self.partnerId = fortData.partnerID != "" ? fortData.partnerID : nil
         if fortData.sponsor != .unset {
             self.sponsorId = UInt16(fortData.sponsor.rawValue)

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -617,11 +617,11 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
         if excludedPowerUpLevels.isEmpty || raidsOnly {
             excludePowerUpLevelsSQL = ""
         } else {
-            var sqlExcludeCreate = "AND (power_up_level NOT IN ("
+            var sqlExcludeCreate = "AND power_up_level NOT IN ("
             for _ in excludedPowerUpLevels {
                 sqlExcludeCreate += "?, "
             }
-            sqlExcludeCreate += "?) AND power_up_end_timestamp >= UNIX_TIMESTAMP())"
+            sqlExcludeCreate += "?)"
             excludePowerUpLevelsSQL = sqlExcludeCreate
         }
 

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -607,21 +607,27 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
             excludeAvailableSlotsSQL = ""
         } else {
             var sqlExcludeCreate = "AND (available_slots NOT IN ("
-            for _ in excludedAvailableSlots {
-                sqlExcludeCreate += "?, "
+            for index in excludedAvailableSlots.indices {
+                if index == excludedAvailableSlots.count - 1 {
+                    sqlExcludeCreate += "?))"
+                } else {
+                    sqlExcludeCreate += "?, "
+                }
             }
-            sqlExcludeCreate += "?))"
             excludeAvailableSlotsSQL = sqlExcludeCreate
         }
 
         if excludedPowerUpLevels.isEmpty || raidsOnly {
             excludePowerUpLevelsSQL = ""
         } else {
-            var sqlExcludeCreate = "AND power_up_level NOT IN ("
-            for _ in excludedPowerUpLevels {
-                sqlExcludeCreate += "?, "
+            var sqlExcludeCreate = "AND (power_up_level NOT IN ("
+            for index in excludedPowerUpLevels.indices {
+                if index == excludedPowerUpLevels.count - 1 {
+                    sqlExcludeCreate += "?))"
+                } else {
+                    sqlExcludeCreate += "?, "
+                }
             }
-            sqlExcludeCreate += "?)"
             excludePowerUpLevelsSQL = sqlExcludeCreate
         }
 

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -930,10 +930,10 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         if excludedPowerUpLevels.isEmpty {
             excludePowerUpLevelsSQL = ""
         } else {
-            var sqlExcludeCreate = "AND power_up_level NOT IN ("
+            var sqlExcludeCreate = "AND (power_up_level NOT IN ("
             for index in excludedPowerUpLevels.indices {
                 if index == excludedPowerUpLevels.count - 1 {
-                    sqlExcludeCreate += "?)"
+                    sqlExcludeCreate += "?))"
                 } else {
                     sqlExcludeCreate += "?, "
                 }

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -931,10 +931,13 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
             excludePowerUpLevelsSQL = ""
         } else {
             var sqlExcludeCreate = "AND power_up_level NOT IN ("
-            for _ in excludedPowerUpLevels {
-                sqlExcludeCreate += "?, "
+            for index in excludedPowerUpLevels.indices {
+                if index == excludedPowerUpLevels.count - 1 {
+                    sqlExcludeCreate += "?)"
+                } else {
+                    sqlExcludeCreate += "?, "
+                }
             }
-            sqlExcludeCreate += "?)"
             excludePowerUpLevelsSQL = sqlExcludeCreate
         }
 

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -934,7 +934,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
             for _ in excludedPowerUpLevels {
                 sqlExcludeCreate += "?, "
             }
-            sqlExcludeCreate += "?"
+            sqlExcludeCreate += "?)"
             excludePowerUpLevelsSQL = sqlExcludeCreate
         }
 

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -621,13 +621,6 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
                 self.lureId = oldPokestop!.lureId
             }
 
-            if oldPokestop!.lureExpireTimestamp != nil && self.lureExpireTimestamp != nil &&
-                   oldPokestop!.lureExpireTimestamp < self.lureExpireTimestamp {
-                if oldPokestop!.incidentExpireTimestamp == nil && self.incidentExpireTimestamp != nil {
-                    self.lureExpireTimestamp = oldPokestop!.lureExpireTimestamp
-                }
-            }
-
             guard Pokestop.shouldUpdate(old: oldPokestop!, new: self) else {
                 return
             }

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -930,11 +930,11 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         if excludedPowerUpLevels.isEmpty {
             excludePowerUpLevelsSQL = ""
         } else {
-            var sqlExcludeCreate = "AND (power_up_level NOT IN ("
+            var sqlExcludeCreate = "AND power_up_level NOT IN ("
             for _ in excludedPowerUpLevels {
                 sqlExcludeCreate += "?, "
             }
-            sqlExcludeCreate += "?) AND power_up_end_timestamp >= UNIX_TIMESTAMP())"
+            sqlExcludeCreate += "?"
             excludePowerUpLevelsSQL = sqlExcludeCreate
         }
 

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -248,17 +248,24 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         }
         self.enabled = fortData.enabled
         self.arScanEligible = fortData.isArScanEligible
+        let now = UInt32(Date().timeIntervalSince1970)
+        let powerUpRemaining = UInt32(fortData.powerUpRemainingUntilMs / 1000)
         self.powerUpPoints = UInt32(fortData.locationPoints)
         if fortData.locationPoints < 50 {
             self.powerUpLevel = 0
-        } else if fortData.locationPoints < 100 {
+        } else if fortData.locationPoints < 100 && powerUpRemaining > now {
             self.powerUpLevel = 1
-        } else if fortData.locationPoints < 150 {
+            self.powerUpEndTimestamp = powerUpRemaining
+        } else if fortData.locationPoints < 150 && powerUpRemaining > now {
             self.powerUpLevel = 2
-        } else {
+            self.powerUpEndTimestamp = powerUpRemaining
+        } else if powerUpRemaining > now {
             self.powerUpLevel = 3
+            self.powerUpEndTimestamp = powerUpRemaining
+        } else {
+            self.powerUpLevel = 0
         }
-        self.powerUpEndTimestamp = UInt32(fortData.powerUpRemainingUntilMs / 1000)
+
         let lastModifiedTimestamp = UInt32(fortData.lastModifiedMs / 1000)
         if fortData.activeFortModifier.contains(.troyDisk) ||
             fortData.activeFortModifier.contains(.troyDiskGlacial) ||
@@ -612,6 +619,13 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
             }
             if oldPokestop!.lureId != nil && self.lureId == nil {
                 self.lureId = oldPokestop!.lureId
+            }
+
+            if oldPokestop!.lureExpireTimestamp != nil && self.lureExpireTimestamp != nil &&
+                   oldPokestop!.lureExpireTimestamp < self.lureExpireTimestamp {
+                if oldPokestop!.incidentExpireTimestamp == nil && self.incidentExpireTimestamp != nil {
+                    self.lureExpireTimestamp = oldPokestop!.lureExpireTimestamp
+                }
             }
 
             guard Pokestop.shouldUpdate(old: oldPokestop!, new: self) else {


### PR DESCRIPTION
### change the way how fort data is extracted for power-up-feature.
powerUpRemaining is always the last valid timestamp, also when power-up expired. Therefore RDM has to compare the timestamp with now. this timestamp is only reseted in FORT if the power up expired AND someone is powering-up again to e.g. 10 points.

### lure (reverted commit)
invasion is extending lure expiration timestamp because invasion changes the "lastModificationTimestamp" of a pokestop. So RDM has to check the timestamp when it saves the fort data.. we need a new solution for that, reverted changes