### PR TITLE
fix static file handler and Charts in Stats

### DIFF
--- a/Sources/RealDeviceMapLib/Web/WebStaticRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Web/WebStaticRequestHandler.swift
@@ -19,7 +19,6 @@ class WebStaticRequestHandler {
             response.setHeader(.cacheControl, value: "max-age=604800, must-revalidate")
         }
         staticFileHandler.handleRequest(request: request, response: response)
-        response.completed()
     }
 
 }

--- a/resources/webroot/header-head.mustache
+++ b/resources/webroot/header-head.mustache
@@ -24,8 +24,8 @@
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.js" integrity="sha256-tfcLorv/GWSrbbsn6NVgflWp1YOmTjyJ8HWtfXaOaJc=" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.18/r-2.2.2/rg-1.1.0/sc-1.5.0/datatables.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/leaflet-easyprint@2.1.9/dist/bundle.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.8/dist/flatpickr.min.js" integrity="sha256-DAgpF7V/btQ6MP2pAnP0k1cNtJe3yJK75MnQLr2+goc=" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/chart.js@2.9.4/dist/Chart.min.js" integrity="sha256-t9UJPrESBeG2ojKTIcFLPGF7nHi2vEc7f5A2KpH/UBU=" crossorigin="anonymous"></script>
     {{#google_analytics_id}}
         <script type="text/javascript" src="//google-analytics.com/analytics.js"></script>
     {{/google_analytics_id}}

--- a/resources/webroot/static/js/utils.js
+++ b/resources/webroot/static/js/utils.js
@@ -37,7 +37,7 @@ function colorize(opaque, hover, ctx) {
     var c = v < -50 ? '#D60000'
         : v < 0 ? '#F46300'
             : v < 50 ? '#0358B6'
-                : '#44DE28';
+                : '#7f887e';
     var opacity = hover ? 1 - Math.abs(v / 150) - 0.2 : 1 - Math.abs(v / 150);
     return opaque ? c : transparentize(c, opacity);
 }


### PR DESCRIPTION
Explanation: 

The staticFileHandler.handleRequest() method takes care of marking the response as completed by calling response.next() which per the HTTPResponse documentation: If there are no further handlers then this is equivalent to calling '.completed()' 

So, with that explicit call in place, I suspect RDM was prematurely marking the response as complete before all the data was transferred.