### PR TITLE
fix sort order when stat product is equal

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
@@ -161,25 +161,6 @@ public class PVPStatsManager {
                 continue
             }
 
-            // debug print BEGIN
-
-            if pokemon.rawValue == 25 && league == .ultra && iv.attack == 15 && iv.defense == 15 && iv.stamina == 14 {
-                Log.info(message: "[TMP] pikachu stats \(iv): \n\(filteredStats)\n")
-            }
-            if pokemon.rawValue == 133 && (league == .great || league == .ultra) && iv.attack == 0 && iv.defense == 15 &&
-                   (iv.stamina == 15 || iv.stamina == 14) {
-                Log.info(message: "[TMP] umbreon stats \(iv): \n\(filteredStats)\n")
-            }
-            if pokemon.rawValue == 661 && league == .ultra && iv.attack == 15 && iv.defense == 15 && iv.stamina == 15 {
-                Log.info(message: "[TMP] fletchling stats \(iv): \n\(filteredStats)\n")
-            }
-            if pokemon.rawValue == 32 && league == .little && iv.attack == 0 && iv.defense == 15 &&
-                   (iv.stamina == 11 || iv.stamina == 12) {
-                Log.info(message: "[TMP] nidoran male stats \(iv): \n\(filteredStats)\n")
-            }
-
-            // debug print END
-
             let max = Double(filteredStats[0].competitionRank)
             let value = Double(rank!.competitionRank)
             let ivs: [Response.IVWithCP]

--- a/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
@@ -147,7 +147,7 @@ public class PVPStatsManager {
             let filteredStats = stats.filter({ $0.cap == lvlCap })
             statLoop: for stat in filteredStats {
                 competitionIndex = ordinalIndex
-                for ivlevel in stat.ivs.sorted(by: { (lhs, rhs) -> Bool in lhs.cp >= rhs.cp }) {
+                for ivlevel in stat.ivs {
                     if ivlevel.iv == iv && ivlevel.level >= level {
                         foundMatch = true
                         rank = stat
@@ -375,7 +375,12 @@ public class PVPStatsManager {
                         ivs: []
                     )
                 }
-                ranking[value]!.ivs.append(.init(iv: iv, level: lowest, cp: bestCP))
+                let index = ranking[value]!.ivs.firstIndex(where: { bestCP >= $0.cp })
+                if index != nil {
+                    ranking[value]!.ivs.insert(.init(iv: iv, level: lowest, cp: bestCP), at: index!)
+                } else {
+                    ranking[value]!.ivs.append(.init(iv: iv, level: lowest, cp: bestCP))
+                }
             }
         }
         return ranking

--- a/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
@@ -394,9 +394,8 @@ public class PVPStatsManager {
                         ivs: []
                     )
                 }
-                let index = ranking[value]!.ivs.firstIndex(where: { bestCP >= $0.cp })
-                if index != nil {
-                    ranking[value]!.ivs.insert(.init(iv: iv, level: lowest, cp: bestCP), at: index!)
+                if let index = ranking[value]!.ivs.firstIndex(where: { bestCP >= $0.cp }) {
+                    ranking[value]!.ivs.insert(.init(iv: iv, level: lowest, cp: bestCP), at: index)
                 } else {
                     ranking[value]!.ivs.append(.init(iv: iv, level: lowest, cp: bestCP))
                 }

--- a/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
@@ -340,7 +340,8 @@ public class PVPStatsManager {
             }
             ranking += calculatePvPStat(stats: stats, cpCap: cpCap, lvlCap: lvlCap)
                     .sorted { (lhs, rhs) -> Bool in
-                        lhs.key >= rhs.key }
+                        // first sort by rank stats product, if equals sort by cp too
+                        (lhs.key, lhs.value.ivs.first!.cp) >= (rhs.key, rhs.value.ivs.first!.cp) }
                     .map { (value) -> Response in
                         value.value }
         }

--- a/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
@@ -161,6 +161,25 @@ public class PVPStatsManager {
                 continue
             }
 
+            // debug print BEGIN
+
+            if pokemon.rawValue == 25 && league == .ultra && iv.attack == 15 && iv.defense == 15 && iv.stamina == 14 {
+                Log.info(message: "[TMP] pikachu stats \(iv): \n\(filteredStats)\n")
+            }
+            if pokemon.rawValue == 133 && (league == .great || league == .ultra) && iv.attack == 0 && iv.defense == 15 &&
+                   (iv.stamina == 15 || iv.stamina == 14) {
+                Log.info(message: "[TMP] umbreon stats \(iv): \n\(filteredStats)\n")
+            }
+            if pokemon.rawValue == 661 && league == .ultra && iv.attack == 15 && iv.defense == 15 && iv.stamina == 15 {
+                Log.info(message: "[TMP] fletchling stats \(iv): \n\(filteredStats)\n")
+            }
+            if pokemon.rawValue == 32 && league == .little && iv.attack == 0 && iv.defense == 15 &&
+                   (iv.stamina == 11 || iv.stamina == 12) {
+                Log.info(message: "[TMP] nidoran male stats \(iv): \n\(filteredStats)\n")
+            }
+
+            // debug print END
+
             let max = Double(filteredStats[0].competitionRank)
             let value = Double(rank!.competitionRank)
             let ivs: [Response.IVWithCP]

--- a/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/PVPStatsManager.swift
@@ -147,7 +147,7 @@ public class PVPStatsManager {
             let filteredStats = stats.filter({ $0.cap == lvlCap })
             statLoop: for stat in filteredStats {
                 competitionIndex = ordinalIndex
-                for ivlevel in stat.ivs {
+                for ivlevel in stat.ivs.sorted(by: { (lhs, rhs) -> Bool in lhs.cp >= rhs.cp }) {
                     if ivlevel.iv == iv && ivlevel.level >= level {
                         foundMatch = true
                         rank = stat
@@ -359,8 +359,7 @@ public class PVPStatsManager {
             }
             ranking += calculatePvPStat(stats: stats, cpCap: cpCap, lvlCap: lvlCap)
                     .sorted { (lhs, rhs) -> Bool in
-                        // first sort by rank stats product, if equals sort by cp too
-                        (lhs.key, lhs.value.ivs.first!.cp) >= (rhs.key, rhs.value.ivs.first!.cp) }
+                        lhs.key >= rhs.key }
                     .map { (value) -> Response in
                         value.value }
         }

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -227,6 +227,7 @@ public func setupRealDeviceMap() {
         PVPStatsManager.lvlCaps = environment["PVP_LEVEL_CAPS"]?.components(separatedBy: ",")
                 .map({ Int($0.trimmingCharacters(in: .whitespaces))! }) ?? [50]
         Log.info(message: "[MAIN] PVP Stats for Level Caps \(String(describing: PVPStatsManager.lvlCaps))")
+        Log.info(message: "[MAIN] PVP Stats defaults to rank type \(pvpRank)")
         _ = PVPStatsManager.global
     } else {
         Log.info(message: "[MAIN] PVP Stats deactivated")


### PR DESCRIPTION
found during implementation:

- stadiumgaming uses `ordinal` ranking
- ohbem uses `competition` ranking

choose your rank type wisely. which tools do you want to match?!