### PR TITLE
Increase device last_host field size 

### DIFF
--- a/resources/migrations/84.sql
+++ b/resources/migrations/84.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `device` MODIFY `last_host` varchar(34) DEFAULT NULL;


### PR DESCRIPTION
## Description
Increase device last_host field size by 4 to store two IP addresses as two IP addresses will not reliably fit in 30 characters.

## Motivation and Context
Bumping from 30 to 34 characters will hold two 16 character IP addresses plus the delimiter when multiple X-ForwardedFor headers are present and "Device Endpoint is behind proxy (Apache/NGINX/etc.)" is enabled. (For example if multiple reverse proxies each add their own XFF header.)
Presently if 30 characters is exceeded the devices disappear off the map.

## How Has This Been Tested?
Manually altering the last_host field resolved the disappearing device issue I was experiencing.
(Running in docker, on master branch, DB_VERSION=81.)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
