### PR TITLE
Remove unused get params from datatables ajax

### DIFF
--- a/resources/webroot/dashboard_instances.mustache
+++ b/resources/webroot/dashboard_instances.mustache
@@ -13,9 +13,13 @@
             "stateDuration": 0,
             "serverSide": true,
             "ajax": {
-                "data": {
-                    "show_instances": true,
-                    "formatted": true
+                data: function (data) {
+                    delete data.columns;
+                    data.show_instances = true;
+                    data.formatted = true;
+                },
+                error: function (xhr, error, thrown) {
+                    console.log(xhr);
                 },
                 "url": "/api/get_data",
                 "dataSrc": "data.instances"


### PR DESCRIPTION
Using CF can cause 414.... GET call with too much params. Approach to fix this