### PR TITLE
fix timeLeft in LevelingInstanceController

### DIFF
--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/LevelingInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/LevelingInstanceController.swift
@@ -267,7 +267,7 @@ class LevelingInstanceController: InstanceControllerProto {
                     startTime.timeIntervalSince1970
             )
             let xpPerHour = Int(Double(xpDelta) / timeDelta * 3600)
-            let timeLeft = Double(xpTarget - xpCurrent) / Double(xpPerHour)
+            let timeLeft = xpPerHour == 0 ? 999.0 : Double(xpTarget - xpCurrent) / Double(xpPerHour)
 
             data.append([
                 "xp_target": xpTarget,


### PR DESCRIPTION
sometimes it was of value `Infinity` which breaks JSON format