### PR TITLE
fix UIcons for unset quest reward

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/ImageManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/ImageManager.swift
@@ -668,7 +668,7 @@ extension ImageManager {
                     index: index["stardust"] as? [String] ?? [String](), postfixes: [])
             case .unset:
                 return ImageManager.global.getFirstNameWithFallback(id: id,
-                    index: [(index["0"] as? String ?? "0")], postfixes: postfixes)
+                    index: index["unset"] as? [String] ?? [String](), postfixes: postfixes)
             default:
                 return ImageManager.global.getFirstNameWithFallback(id: id,
                 index: index["\(type)"] as? [String] ?? [String](), postfixes: postfixes)


### PR DESCRIPTION
for dashboard stats it was always used this file: [PkmnShuffleMap](https://github.com/nileplumb/PkmnShuffleMap/blob/master/UICONS/reward/0.png)

But unfortuanetely this does not exist on every repo. But what should exist to follow UIcons guiding style is [this](https://github.com/nileplumb/PkmnShuffleMap/blob/master/UICONS/reward/unset/0.png)

only used for stats page... so if you update pls also update your UIcon repo.. Might be that this was added lately.