### PR TITLE
More caching

### DIFF
--- a/Sources/RealDeviceMapLib/Modell/Cell.swift
+++ b/Sources/RealDeviceMapLib/Modell/Cell.swift
@@ -20,8 +20,7 @@ class Cell: JSONConvertibleObject {
     var centerLon: Double
     var updated: UInt32?
 
-    public static var cache: MemoryCache<UInt32> =
-        MemoryCache(interval: 900, keepTime: 3600)
+    public static var cacheFuncSave: MemoryCache<Int8> = MemoryCache(interval: 60, keepTime: 900, extendTtlOnAccess: false)
 
     override func getJSONValues() -> [String: Any] {
 
@@ -57,10 +56,10 @@ class Cell: JSONConvertibleObject {
             Log.error(message: "[CELL] Failed to connect to database.")
             throw DBController.DBError()
         }
-        let updated = Cell.cache.get(id: id.toString()) ?? 0
-        let now = UInt32(Date().timeIntervalSince1970)
-        if updated > now - 900 {
-            // save only every 15 minutes
+
+        let updated = Cell.cacheFuncSave.get(id: id.toString()) ?? 0
+        if updated > 0
+        {
             return
         }
 
@@ -85,7 +84,7 @@ class Cell: JSONConvertibleObject {
             Log.error(message: "[CELL] Failed to execute query. (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
-        Cell.cache.set(id: id.toString(), value: now)
+        Cell.cacheFuncSave.set(id: id.toString(), value: 1)
     }
 
     public static func getAll(mysql: MySQL?=nil, minLat: Double, maxLat: Double,


### PR DESCRIPTION
Add caching to gym and pokestop clearOld functions to decrease query load on database for offending models.

## Description
1. Modified MemoryCache.swift to have the option to not reset ttl when value is checked.  Default parameters maintain prior funcitonality, i.e. 'extendTtlOnAccess' is true, so no updates from existing code required.  Setting 'extendTtlOnAccess' to false will create the redis style cache of keys that don't extend ttl on access, so they expire at a time from creation of key.
2. The updates I have made here do not extend ttl when accessed, as I allow the mem cache to handle expires.
3. Added caching of clearOld functions in Gym.swift and Pokestop.swift to reduce update spam.
4. Updated Cell.swift to match above convention.
5. As with above model edits, quick check for key existence in the model.  We just check if it exists, if it does return, if not do sql and update cache.
6. ttl for cached data is nearly random values I chose to reduce update queries coming for clearOld functions.  I am very open to suggestions since I have only been running RDM for a bit over a month.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
RDM was killing my database with repeated and unnecessary updates of data that doesn't need to be updated on a constant basis, such as pokestop and gym deletes.  As outlined below, able to drop update query spam substantially.  I have horrible internet and use mysql replication, which was having issues with too many update queries that weren't needed.

Future work:
1. Do we consider implementing full on redis caching?  Basic caching like this works, plus does not require end user to install yet another program, even though redis is dead simple.
2. Is there other models that would benefit from caching in order to reduce loads on db.  I kept things simple for this pr.

<!--- If it fixes an open issue, please link to the issue here. -->
No open issue related to this pr, but does extend the s2 cell pr.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Verified reduction of query quantity via mysql workbench and examining query logs.
1. Prior to s2 cell update, i was seeing ~1.7k updates/sec from 17 atv running atlas.
2. With s2 cell update to cache data, the rate dropped to ~1k updates/sec.
3. With these updates applied, I am seeing ~200 updates/sec.

<!--- Include details of your testing environment, and the tests you ran to -->
My own machine running rdm.  Minipc, Ryzen9 5900hx, 32gb ram and 1tb samsung 980 gen3 nvme.

I do not run in docker, installed swift and run rdm from the command line.  For extended operation, I utilize pm2.

Setup debug logging statements to put output to console, which was piped into a file.  Examine file to indeed verify there was a cache miss of item generating sql update, cache hits for time period specified and then a cache miss causing sql update.

Examined mysql query logs of all scenarios to verify there was less update query spam from clearOld functions.

Logs of queries executed on database can be provided upon request.

<!--- see how your change affects other areas of the code, etc. -->
Don't see any changes affecting other areas negatively, as reducing load on db at the expense of small amount of memory use for caching should help out the generally running of the system.  I run a high end machine for scanning, but have db issues due to above.  Reducing database load should be a win for every situation of processing power, internet connection, etc.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix any issues they point out. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
