### PR TITLE
Fort insert/update rework

### DIFF
--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2259,7 +2259,6 @@ public class ApiRequestHandler {
                     return response.respondWithError(status: .custom(code: 404, message: "Gym not found"))
                 }
                 oldGym.name = name
-                oldGym.hasChanges = true
                 try oldGym.save()
                 response.respondWithOk()
             } catch {

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2255,7 +2255,7 @@ public class ApiRequestHandler {
 
         if setGymName, perms.contains(.admin), let id = gymId, let name = gymName {
             do {
-                guard let oldGym = try Gym.getWithId(id: id) else {
+                guard let oldGym = try Gym.getWithId(id: id, copy: true) else {
                     return response.respondWithError(status: .custom(code: 404, message: "Gym not found"))
                 }
                 oldGym.name = name
@@ -2266,11 +2266,10 @@ public class ApiRequestHandler {
             }
         } else if setPokestopName, perms.contains(.admin), let id = pokestopId, let name = pokestopName {
            do {
-               guard let oldPokestop = try Pokestop.getWithId(id: id) else {
+               guard let oldPokestop = try Pokestop.getWithId(id: id, copy: true) else {
                    return response.respondWithError(status: .custom(code: 404, message: "Pokestop not found"))
                }
                oldPokestop.name = name
-               oldPokestop.hasChanges = true
                try oldPokestop.save()
                response.respondWithOk()
            } catch {

--- a/Sources/RealDeviceMapLib/Controller/WebHookController.swift
+++ b/Sources/RealDeviceMapLib/Controller/WebHookController.swift
@@ -44,8 +44,6 @@ public class WebHookController {
     private var alternativeQuestEvents = [String: Pokestop]()
     private var gymEventLock = Threading.Lock()
     private var gymEvents = [String: Gym]()
-    private var gymInfoEventLock = Threading.Lock()
-    private var gymInfoEvents = [String: Gym]()
     private var eggEventLock = Threading.Lock()
     private var eggEvents = [String: Gym]()
     private var raidEventLock = Threading.Lock()
@@ -94,12 +92,6 @@ public class WebHookController {
     public func addGymEvent(gym: Gym) {
         if !self.webhooks.isEmpty && self.types.contains(.gym) {
             gymEventLock.doWithLock { gymEvents[gym.id] = gym }
-        }
-    }
-
-    public func addGymInfoEvent(gym: Gym) {
-        if !self.webhooks.isEmpty && self.types.contains(.gym) {
-            gymInfoEventLock.doWithLock { gymInfoEvents[gym.id] = gym }
         }
     }
 
@@ -171,7 +163,6 @@ public class WebHookController {
                         var questEvents = [String: Pokestop]()
                         var alternativeQuestEvents = [String: Pokestop]()
                         var gymEvents = [String: Gym]()
-                        var gymInfoEvents = [String: Gym]()
                         var eggEvents = [String: Gym]()
                         var raidEvents = [String: Gym]()
                         var weatherEvents = [Int64: Weather]()
@@ -210,11 +201,6 @@ public class WebHookController {
                         self.gymEventLock.doWithLock {
                             gymEvents = self.gymEvents
                             self.gymEvents = [String: Gym]()
-                        }
-
-                        self.gymInfoEventLock.doWithLock {
-                            gymInfoEvents = self.gymInfoEvents
-                            self.gymInfoEvents = [String: Gym]()
                         }
 
                         self.raidEventLock.doWithLock {
@@ -330,15 +316,6 @@ public class WebHookController {
                                             continue
                                         }
                                         events.append(gym.getWebhookValues(type: WebhookType.gym.rawValue))
-                                    }
-                                }
-                                for (_, gymInfo) in gymInfoEvents {
-                                    if area.isEmpty ||
-                                           self.inPolygon(lat: gymInfo.lat, lon: gymInfo.lon, multiPolygon: polygon) {
-                                        if gymIDs.contains(Int(gymInfo.teamId ?? 0)) {
-                                            continue
-                                        }
-                                        events.append(gymInfo.getWebhookValues(type: "gym-info"))
                                     }
                                 }
                             }

--- a/Sources/RealDeviceMapLib/Misc/MemoryCache.swift
+++ b/Sources/RealDeviceMapLib/Misc/MemoryCache.swift
@@ -15,8 +15,10 @@ public class MemoryCache<T> {
     private var store = [String: T]()
     private let hitsLock = Threading.Lock()
     private var hits = [String: Date]()
+    private var extendTtl: Bool
 
-    public init(interval: Double, keepTime: Double) {
+    public init(interval: Double, keepTime: Double, extendTtlOnAccess: Bool = true) {
+        extendTtl = extendTtlOnAccess
         let clearingQueue = Threading.getQueue(name: "MemoryCache-\(UUID().uuidString)-clearer", type: .serial)
         clearingQueue.dispatch {
             while true {
@@ -42,7 +44,7 @@ public class MemoryCache<T> {
         lock.readLock()
         let value = store[id]
         lock.unlock()
-        if value != nil {
+        if extendTtl && value != nil {
             hitsLock.lock()
             hits[id] = Date()
             hitsLock.unlock()

--- a/Sources/RealDeviceMapLib/Misc/MemoryCache.swift
+++ b/Sources/RealDeviceMapLib/Misc/MemoryCache.swift
@@ -15,10 +15,10 @@ public class MemoryCache<T> {
     private var store = [String: T]()
     private let hitsLock = Threading.Lock()
     private var hits = [String: Date]()
-    private var extendTtl: Bool
+    private var extendTtlOnHit: Bool
 
-    public init(interval: Double, keepTime: Double, extendTtlOnAccess: Bool = true) {
-        extendTtl = extendTtlOnAccess
+    public init(interval: Double, keepTime: Double, extendTtlOnHit: Bool = true) {
+        self.extendTtlOnHit = extendTtlOnHit
         let clearingQueue = Threading.getQueue(name: "MemoryCache-\(UUID().uuidString)-clearer", type: .serial)
         clearingQueue.dispatch {
             while true {
@@ -44,7 +44,7 @@ public class MemoryCache<T> {
         lock.readLock()
         let value = store[id]
         lock.unlock()
-        if extendTtl && value != nil {
+        if extendTtlOnHit && value != nil {
             hitsLock.lock()
             hits[id] = Date()
             hitsLock.unlock()

--- a/Sources/RealDeviceMapLib/Misc/PokemonFortProto.swift
+++ b/Sources/RealDeviceMapLib/Misc/PokemonFortProto.swift
@@ -1,0 +1,31 @@
+//
+// Created by fabio on 17.08.22.
+//
+
+import Foundation
+import POGOProtos
+
+extension PokemonFortProto {
+
+    func calculatePowerUpPoints(now: UInt32) -> (level: UInt16, timestamp: UInt32?) {
+        let powerUpLevelExpirationMs = UInt32(powerUpLevelExpirationMs / 1000)
+        let powerUpPoints = powerUpProgressPoints
+        var powerUpLevel: UInt16 = 0
+        var powerUpEndTimestamp: UInt32?
+        if powerUpPoints < 50 {
+            powerUpLevel = 0
+        } else if powerUpPoints < 100 && powerUpLevelExpirationMs > now {
+            powerUpLevel = 1
+            powerUpEndTimestamp = powerUpLevelExpirationMs
+        } else if powerUpPoints < 150 && powerUpLevelExpirationMs > now {
+            powerUpLevel = 2
+            powerUpEndTimestamp = powerUpLevelExpirationMs
+        } else if powerUpLevelExpirationMs > now {
+            powerUpLevel = 3
+            powerUpEndTimestamp = powerUpLevelExpirationMs
+        } else {
+            powerUpLevel = 0
+        }
+        return (powerUpLevel, powerUpEndTimestamp)
+    }
+}

--- a/Sources/RealDeviceMapLib/Misc/PokemonFortProto.swift
+++ b/Sources/RealDeviceMapLib/Misc/PokemonFortProto.swift
@@ -7,7 +7,7 @@ import POGOProtos
 
 extension PokemonFortProto {
 
-    func calculatePowerUpPoints(now: UInt32) -> (level: UInt16, timestamp: UInt32?) {
+    func calculatePowerUpLevel(now: UInt32) -> (level: UInt16, timestamp: UInt32?) {
         let powerUpLevelExpirationMs = UInt32(powerUpLevelExpirationMs / 1000)
         let powerUpPoints = powerUpProgressPoints
         var powerUpLevel: UInt16 = 0

--- a/Sources/RealDeviceMapLib/Modell/Cell.swift
+++ b/Sources/RealDeviceMapLib/Modell/Cell.swift
@@ -18,10 +18,11 @@ class Cell: JSONConvertibleObject {
     var level: UInt8
     var centerLat: Double
     var centerLon: Double
+    var stopCount: Int = 0
+    var gymCount: Int = 0
     var updated: UInt32?
 
-    public static var cache: MemoryCache<UInt32> =
-        MemoryCache(interval: 900, keepTime: 3600)
+    public static var cache: MemoryCache<Cell> = MemoryCache(interval: 900, keepTime: 3600)
 
     override func getJSONValues() -> [String: Any] {
 
@@ -57,11 +58,18 @@ class Cell: JSONConvertibleObject {
             Log.error(message: "[CELL] Failed to connect to database.")
             throw DBController.DBError()
         }
-        let updated = Cell.cache.get(id: id.toString()) ?? 0
+        let oldCell = Cell.cache.get(id: id.toString())
         let now = UInt32(Date().timeIntervalSince1970)
-        if updated > now - 900 {
+        if oldCell != nil && oldCell!.updated ?? 0 > now - 900 {
             // save only every 15 minutes
             return
+        }
+        if oldCell != nil {
+            // stop and gym count is only stored in cache
+            Log.debug(message: "[CELL] stopCount \(self.stopCount) -> \(oldCell!.stopCount)")
+            Log.debug(message: "[CELL] gymCount \(self.gymCount) -> \(oldCell!.gymCount)")
+            self.stopCount = oldCell!.stopCount
+            self.gymCount = oldCell!.gymCount
         }
 
         let sql = """
@@ -85,7 +93,7 @@ class Cell: JSONConvertibleObject {
             Log.error(message: "[CELL] Failed to execute query. (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
-        Cell.cache.set(id: id.toString(), value: now)
+        Cell.cache.set(id: id.toString(), value: self)
     }
 
     public static func getAll(mysql: MySQL?=nil, minLat: Double, maxLat: Double,
@@ -198,5 +206,4 @@ class Cell: JSONConvertibleObject {
         return cells
 
     }
-
 }

--- a/Sources/RealDeviceMapLib/Modell/Cell.swift
+++ b/Sources/RealDeviceMapLib/Modell/Cell.swift
@@ -22,7 +22,7 @@ class Cell: JSONConvertibleObject {
     var gymCount: Int = 0
     var updated: UInt32?
 
-    public static var cache: MemoryCache<Cell> = MemoryCache(interval: 900, keepTime: 3600)
+    public static var cache: MemoryCache<Cell>?
 
     override func getJSONValues() -> [String: Any] {
 
@@ -58,7 +58,7 @@ class Cell: JSONConvertibleObject {
             Log.error(message: "[CELL] Failed to connect to database.")
             throw DBController.DBError()
         }
-        let oldCell = Cell.cache.get(id: id.toString())
+        let oldCell = Cell.cache?.get(id: id.toString())
         let now = UInt32(Date().timeIntervalSince1970)
         if oldCell != nil && oldCell!.updated ?? 0 > now - 900 {
             // save only every 15 minutes
@@ -93,7 +93,7 @@ class Cell: JSONConvertibleObject {
             Log.error(message: "[CELL] Failed to execute query. (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
-        Cell.cache.set(id: id.toString(), value: self)
+        Cell.cache?.set(id: id.toString(), value: self)
     }
 
     public static func getAll(mysql: MySQL?=nil, minLat: Double, maxLat: Double,

--- a/Sources/RealDeviceMapLib/Modell/Cell.swift
+++ b/Sources/RealDeviceMapLib/Modell/Cell.swift
@@ -67,8 +67,6 @@ class Cell: JSONConvertibleObject {
         }
         if oldCell != nil {
             // stop and gym count is only stored in cache
-            Log.debug(message: "[CELL] stopCount \(self.stopCount) <- \(oldCell!.stopCount)")
-            Log.debug(message: "[CELL] gymCount \(self.gymCount) <- \(oldCell!.gymCount)")
             self.stopCount = oldCell!.stopCount
             self.gymCount = oldCell!.gymCount
         }

--- a/Sources/RealDeviceMapLib/Modell/Cell.swift
+++ b/Sources/RealDeviceMapLib/Modell/Cell.swift
@@ -18,9 +18,10 @@ class Cell: JSONConvertibleObject {
     var level: UInt8
     var centerLat: Double
     var centerLon: Double
+    var updated: UInt32?
+
     var stopCount: Int = 0
     var gymCount: Int = 0
-    var updated: UInt32?
 
     public static var cache: MemoryCache<Cell>?
 
@@ -66,8 +67,8 @@ class Cell: JSONConvertibleObject {
         }
         if oldCell != nil {
             // stop and gym count is only stored in cache
-            Log.debug(message: "[CELL] stopCount \(self.stopCount) -> \(oldCell!.stopCount)")
-            Log.debug(message: "[CELL] gymCount \(self.gymCount) -> \(oldCell!.gymCount)")
+            Log.debug(message: "[CELL] stopCount \(self.stopCount) <- \(oldCell!.stopCount)")
+            Log.debug(message: "[CELL] gymCount \(self.gymCount) <- \(oldCell!.gymCount)")
             self.stopCount = oldCell!.stopCount
             self.gymCount = oldCell!.gymCount
         }

--- a/Sources/RealDeviceMapLib/Modell/Cell.swift
+++ b/Sources/RealDeviceMapLib/Modell/Cell.swift
@@ -65,15 +65,15 @@ class Cell: JSONConvertibleObject {
             // save only every 15 minutes
             return
         }
-        if oldCell != nil {
-            // stop and gym count is only stored in cache
-            self.stopCount = oldCell!.stopCount
-            self.gymCount = oldCell!.gymCount
-        }
+
+        self.updated = now
+        // stop and gym count is only stored in cache
+        self.stopCount = oldCell?.stopCount ?? 0
+        self.gymCount = oldCell?.gymCount ?? 0
 
         let sql = """
         INSERT INTO `s2cell` (id, level, center_lat, center_lon, updated)
-        VALUES (?, ?, ?, ?, UNIX_TIMESTAMP())
+        VALUES (?, ?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE
         level=VALUES(level),
         center_lat=VALUES(center_lat),
@@ -87,6 +87,7 @@ class Cell: JSONConvertibleObject {
         mysqlStmt.bindParam(level)
         mysqlStmt.bindParam(centerLat)
         mysqlStmt.bindParam(centerLon)
+        mysqlStmt.bindParam(updated)
 
         guard mysqlStmt.execute() else {
             Log.error(message: "[CELL] Failed to execute query. (\(mysqlStmt.errorMessage())")

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -228,7 +228,7 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
         self.inBattle = fortData.isInBattle
         self.arScanEligible = fortData.isArScanEligible
         self.powerUpPoints = UInt32(fortData.powerUpProgressPoints)
-        (self.powerUpLevel, self.powerUpEndTimestamp) = calculatePowerUpPoints(fortData: fortData, now: now)
+        (self.powerUpLevel, self.powerUpEndTimestamp) = fortData.calculatePowerUpPoints(now: now)
 
         self.partnerId = fortData.partnerID != "" ? fortData.partnerID : nil
 
@@ -270,7 +270,7 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
         self.cellId = cellId
     }
 
-    public func updateFromFortDetails(fortData: FortDetailsOutProto) {
+    func updateFromFortDetails(fortData: FortDetailsOutProto) {
         self.id = fortData.id
         self.lat = fortData.latitude
         self.lon = fortData.longitude
@@ -286,10 +286,9 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
         } else {
             self.promoDescription = nil
         }
-
     }
 
-    public func updateFromGymInfo(gymInfo: GymGetInfoOutProto) {
+    func updateFromGymInfo(gymInfo: GymGetInfoOutProto) {
         self.name = gymInfo.name
         self.description = gymInfo.description_p
         if !gymInfo.url.isEmpty {
@@ -1088,28 +1087,6 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
             }
         }
 
-    }
-
-    private func calculatePowerUpPoints(fortData: PokemonFortProto, now: UInt32) -> (UInt16, UInt32?) {
-        let powerUpLevelExpirationMs = UInt32(fortData.powerUpLevelExpirationMs / 1000)
-        let powerUpPoints = fortData.powerUpProgressPoints
-        var powerUpLevel: UInt16 = 0
-        var powerUpEndTimestamp: UInt32?
-        if powerUpPoints < 50 {
-            powerUpLevel = 0
-        } else if powerUpPoints < 100 && powerUpLevelExpirationMs > now {
-            powerUpLevel = 1
-            powerUpEndTimestamp = powerUpLevelExpirationMs
-        } else if powerUpPoints < 150 && powerUpLevelExpirationMs > now {
-            powerUpLevel = 2
-            powerUpEndTimestamp = powerUpLevelExpirationMs
-        } else if powerUpLevelExpirationMs > now {
-            powerUpLevel = 3
-            powerUpEndTimestamp = powerUpLevelExpirationMs
-        } else {
-            powerUpLevel = 0
-        }
-        return (powerUpLevel, powerUpEndTimestamp)
     }
 
     private static func hasChanges(old: Gym, new: Gym) -> Bool {

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -80,9 +80,6 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
                 "total_cp": totalCp ?? 0,
                 "sponsor_id": sponsorId ?? 0,
                 "partner_id": partnerId ?? 0,
-                "power_up_points": powerUpPoints ?? 0,
-                "power_up_level": powerUpLevel ?? 0,
-                "power_up_end_timestamp": powerUpEndTimestamp ?? 0,
                 "ar_scan_eligible": arScanEligible ?? 0,
                 "power_up_points": powerUpPoints ?? 0,
                 "power_up_level": powerUpLevel ?? 0,
@@ -1057,8 +1054,8 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
     // =================================================================================================================
 
     private static func createGymWebhooks(old: Gym?, new: Gym) {
-        if old == nil ||
-               old!.availableSlots != new.availableSlots || old!.teamId != new.teamId || old!.inBattle != new.inBattle {
+        if old == nil || old!.name != new.name || old!.availableSlots != new.availableSlots ||
+               old!.teamId != new.teamId || old!.inBattle != new.inBattle {
             WebHookController.global.addGymEvent(gym: new)
         }
         if new.raidSpawnTimestamp ?? 0 > 0 && (

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -243,7 +243,7 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
         } else {
             if fortData.hasGymDisplay {
                 let totalCp = UInt32(fortData.gymDisplay.totalGymCp)
-                if (self.totalCp ?? 0) - totalCp > 100 || totalCp - (self.totalCp ?? 0) > 100 ||
+                if (self.totalCp ?? 0) > totalCp + 100 || totalCp > (self.totalCp ?? 0) + 100 ||
                        (self.updated ?? 0) < now - 600 {
                     // update only when total cp changed more than 100 or when last updated was 10 minutes ago
                     self.totalCp = totalCp

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -130,6 +130,8 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
     var lon: Double
 
     var name: String?
+    var description: String?
+    var promoDescription: String?
     var url: String?
     var guardPokemonId: UInt16?
     var enabled: Bool?
@@ -154,7 +156,7 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
     var raidIsExclusive: Bool?
     var cellId: UInt64?
     var totalCp: UInt32?
-    var sponsorId: UInt16?
+    var sponsorId: UInt16? // unused
     var partnerId: String?
     var arScanEligible: Bool?
     var powerUpPoints: UInt32?
@@ -230,9 +232,6 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
 
         self.partnerId = fortData.partnerID != "" ? fortData.partnerID : nil
 
-        if fortData.sponsor != .unset {
-            self.sponsorId = UInt16(fortData.sponsor.rawValue)
-        }
         if fortData.imageURL != "" {
             self.url = fortData.imageURL
         }
@@ -279,12 +278,28 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
             self.url = fortData.imageURL[0]
         }
         self.name = fortData.name
+        self.description = fortData.description_p
+
+        if fortData.promoDescription.count != 0 {
+            self.promoDescription = fortData.promoDescription.jsonEncodeForceTry()
+            Log.debug(message: "[GYM] \(id) with promo: \(promoDescription ?? "")")
+        } else {
+            self.promoDescription = nil
+        }
+
     }
 
     public func updateFromGymInfo(gymInfo: GymGetInfoOutProto) {
         self.name = gymInfo.name
+        self.description = gymInfo.description_p
         if !gymInfo.url.isEmpty {
             self.url = gymInfo.url
+        }
+        if gymInfo.promoDescription.count != 0 {
+            self.promoDescription = gymInfo.promoDescription.jsonEncodeForceTry()
+            Log.debug(message: "[GYM] \(id) with promo: \(promoDescription ?? "")")
+        } else {
+            self.promoDescription = nil
         }
     }
 

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -228,7 +228,7 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
         self.inBattle = fortData.isInBattle
         self.arScanEligible = fortData.isArScanEligible
         self.powerUpPoints = UInt32(fortData.powerUpProgressPoints)
-        (self.powerUpLevel, self.powerUpEndTimestamp) = fortData.calculatePowerUpPoints(now: now)
+        (self.powerUpLevel, self.powerUpEndTimestamp) = fortData.calculatePowerUpLevel(now: now)
 
         self.partnerId = fortData.partnerID != "" ? fortData.partnerID : nil
 

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -64,8 +64,8 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
         if type == "gym" {
             realType = "gym"
             message = [
-                "gym_id": id,
-                "gym_name": name ?? "Unknown",
+                "id": id,
+                "name": name ?? "Unknown",
                 "latitude": lat,
                 "longitude": lon,
                 "url": url ?? "",
@@ -74,7 +74,6 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
                 "last_modified": lastModifiedTimestamp ?? 0,
                 "guard_pokemon_id": guardPokemonId ?? 0,
                 "slots_available": availableSlots ?? 6,
-                "raid_active_until": raidEndTimestamp ?? 0,
                 "ex_raid_eligible": exRaidEligible ?? 0,
                 "in_battle": inBattle ?? false,
                 "total_cp": totalCp ?? 0,

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -76,12 +76,17 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
                 "slots_available": availableSlots ?? 6,
                 "raid_active_until": raidEndTimestamp ?? 0,
                 "ex_raid_eligible": exRaidEligible ?? 0,
+                "in_battle": inBattle ?? false,
+                "total_cp": totalCp ?? 0,
                 "sponsor_id": sponsorId ?? 0,
                 "partner_id": partnerId ?? 0,
                 "power_up_points": powerUpPoints ?? 0,
                 "power_up_level": powerUpLevel ?? 0,
                 "power_up_end_timestamp": powerUpEndTimestamp ?? 0,
-                "ar_scan_eligible": arScanEligible ?? 0
+                "ar_scan_eligible": arScanEligible ?? 0,
+                "power_up_points": powerUpPoints ?? 0,
+                "power_up_level": powerUpLevel ?? 0,
+                "power_up_end_timestamp": powerUpEndTimestamp ?? 0
             ]
         } else if type == "egg" || type == "raid" {
             realType = "raid"
@@ -107,11 +112,7 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
                 "ex_raid_eligible": exRaidEligible ?? 0,
                 "is_exclusive": raidIsExclusive ?? false,
                 "sponsor_id": sponsorId ?? 0,
-                "partner_id": partnerId ?? 0,
-                "power_up_points": powerUpPoints ?? 0,
-                "power_up_level": powerUpLevel ?? 0,
-                "power_up_end_timestamp": powerUpEndTimestamp ?? 0,
-                "ar_scan_eligible": arScanEligible ?? 0
+                "partner_id": partnerId ?? 0
             ]
         } else {
             realType = "unknown"

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -129,8 +129,6 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
     var lon: Double
 
     var name: String?
-    var description: String?
-    var promoDescription: String?
     var url: String?
     var guardPokemonId: UInt16?
     var enabled: Bool?
@@ -277,28 +275,15 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
             self.url = fortData.imageURL[0]
         }
         self.name = fortData.name
-        self.description = fortData.description_p
-
-        if fortData.promoDescription.count != 0 {
-            self.promoDescription = fortData.promoDescription.jsonEncodeForceTry()
-            Log.debug(message: "[GYM] \(id) with promo: \(promoDescription ?? "")")
-        } else {
-            self.promoDescription = nil
-        }
+//        self.description = gymInfo.description_p
     }
 
     func updateFromGymInfo(gymInfo: GymGetInfoOutProto) {
         self.name = gymInfo.name
-        self.description = gymInfo.description_p
         if !gymInfo.url.isEmpty {
             self.url = gymInfo.url
         }
-        if gymInfo.promoDescription.count != 0 {
-            self.promoDescription = gymInfo.promoDescription.jsonEncodeForceTry()
-            Log.debug(message: "[GYM] \(id) with promo: \(promoDescription ?? "")")
-        } else {
-            self.promoDescription = nil
-        }
+//        self.description = gymInfo.description_p
     }
 
     public func save(mysql: MySQL?=nil) throws {

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -12,7 +12,7 @@ import PerfectLib
 import PerfectMySQL
 import POGOProtos
 
-public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
+public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
 
     public static var exRaidBossId: UInt16?
     public static var exRaidBossForm: UInt16?
@@ -76,26 +76,6 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
                 "slots_available": availableSlots ?? 6,
                 "raid_active_until": raidEndTimestamp ?? 0,
                 "ex_raid_eligible": exRaidEligible ?? 0,
-                "sponsor_id": sponsorId ?? 0,
-                "partner_id": partnerId ?? 0,
-                "power_up_points": powerUpPoints ?? 0,
-                "power_up_level": powerUpLevel ?? 0,
-                "power_up_end_timestamp": powerUpEndTimestamp ?? 0,
-                "ar_scan_eligible": arScanEligible ?? 0
-            ]
-        } else if type == "gym-info" {
-            realType = "gym_details"
-            message = [
-                "id": id,
-                "name": name ?? "Unknown",
-                "url": url ?? "",
-                "latitude": lat,
-                "longitude": lon,
-                "team": teamId ?? 0,
-                "guard_pokemon_id": guardPokemonId ?? 0,
-                "slots_available": availableSlots ?? 6,
-                "ex_raid_eligible": exRaidEligible ?? 0,
-                "in_battle": inBattle ?? false,
                 "sponsor_id": sponsorId ?? 0,
                 "partner_id": partnerId ?? 0,
                 "power_up_points": powerUpPoints ?? 0,
@@ -183,10 +163,13 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
     var powerUpLevel: UInt16?
     var powerUpEndTimestamp: UInt32?
 
-    var hasChanges = false
-
     public static var cache: MemoryCache<Gym>?
 
+    override init() {
+        self.id = ""
+        self.lat = 0.0
+        self.lon = 0.0
+    }
     init(id: String, lat: Double, lon: Double, name: String?, url: String?, guardPokemonId: UInt16?, enabled: Bool?,
          lastModifiedTimestamp: UInt32?, teamId: UInt8?, raidEndTimestamp: UInt32?, raidSpawnTimestamp: UInt32?,
          raidBattleTimestamp: UInt32?, raidPokemonId: UInt16?, raidLevel: UInt8?, availableSlots: UInt16?,
@@ -231,7 +214,8 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
         self.powerUpEndTimestamp = powerUpEndTimestamp
     }
 
-    init(fortData: PokemonFortProto, cellId: UInt64) {
+    func updateFromFort(fortData: PokemonFortProto, cellId: UInt64) {
+        let now = UInt32(Date().timeIntervalSince1970)
         self.id = fortData.fortID
         self.lat = fortData.latitude
         self.lon = fortData.longitude
@@ -243,25 +227,11 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
         self.exRaidEligible = fortData.isExRaidEligible
         self.inBattle = fortData.isInBattle
         self.arScanEligible = fortData.isArScanEligible
-        let now = UInt32(Date().timeIntervalSince1970)
-        let powerUpLevelExpirationMs = UInt32(fortData.powerUpLevelExpirationMs / 1000)
         self.powerUpPoints = UInt32(fortData.powerUpProgressPoints)
-        if fortData.powerUpProgressPoints < 50 {
-            self.powerUpLevel = 0
-        } else if fortData.powerUpProgressPoints < 100 && powerUpLevelExpirationMs > now {
-            self.powerUpLevel = 1
-            self.powerUpEndTimestamp = powerUpLevelExpirationMs
-        } else if fortData.powerUpProgressPoints < 150 && powerUpLevelExpirationMs > now {
-            self.powerUpLevel = 2
-            self.powerUpEndTimestamp = powerUpLevelExpirationMs
-        } else if powerUpLevelExpirationMs > now {
-            self.powerUpLevel = 3
-            self.powerUpEndTimestamp = powerUpLevelExpirationMs
-        } else {
-            self.powerUpLevel = 0
-        }
+        (self.powerUpLevel, self.powerUpEndTimestamp) = calculatePowerUpPoints(fortData: fortData, now: now)
 
         self.partnerId = fortData.partnerID != "" ? fortData.partnerID : nil
+
         if fortData.sponsor != .unset {
             self.sponsorId = UInt16(fortData.sponsor.rawValue)
         }
@@ -271,7 +241,16 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
         if fortData.team == .unset {
             self.totalCp = 0
         } else {
-            self.totalCp = UInt32(fortData.gymDisplay.totalGymCp)
+            if fortData.hasGymDisplay {
+                let totalCp = UInt32(fortData.gymDisplay.totalGymCp)
+                if (self.totalCp ?? 0) - totalCp > 100 || totalCp - (self.totalCp ?? 0) > 100 ||
+                       (self.updated ?? 0) < now - 600 {
+                    // update only when total cp changed more than 100 or when last updated was 10 minutes ago
+                    self.totalCp = totalCp
+                }
+            } else {
+                self.totalCp = 0
+            }
         }
 
         if fortData.hasRaidInfo {
@@ -279,46 +258,36 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
             self.raidSpawnTimestamp = UInt32(fortData.raidInfo.raidSpawnMs / 1000)
             self.raidBattleTimestamp = UInt32(fortData.raidInfo.raidBattleMs / 1000)
             self.raidLevel = UInt8(fortData.raidInfo.raidLevel.rawValue)
+            self.raidIsExclusive = fortData.raidInfo.isExclusive
             self.raidPokemonId = UInt16(fortData.raidInfo.raidPokemon.pokemonID.rawValue)
             self.raidPokemonMove1 = UInt16(fortData.raidInfo.raidPokemon.move1.rawValue)
             self.raidPokemonMove2 = UInt16(fortData.raidInfo.raidPokemon.move2.rawValue)
             self.raidPokemonForm = UInt16(fortData.raidInfo.raidPokemon.pokemonDisplay.form.rawValue)
             self.raidPokemonCp = UInt32(fortData.raidInfo.raidPokemon.cp)
             self.raidPokemonGender = UInt8(fortData.raidInfo.raidPokemon.pokemonDisplay.gender.rawValue)
-            self.raidIsExclusive = fortData.raidInfo.isExclusive
             self.raidPokemonCostume = UInt16(fortData.raidInfo.raidPokemon.pokemonDisplay.costume.rawValue)
             self.raidPokemonEvolution = UInt8(
                 fortData.raidInfo.raidPokemon.pokemonDisplay.currentTempEvolution.rawValue
             )
         }
-
         self.cellId = cellId
-
     }
 
-    public func addDetails(fortData: FortDetailsOutProto) {
+    public func updateFromFortDetails(fortData: FortDetailsOutProto) {
+        self.id = fortData.id
+        self.lat = fortData.latitude
+        self.lon = fortData.longitude
         if !fortData.imageURL.isEmpty {
-            let url = fortData.imageURL[0]
-            if self.url != url {
-                hasChanges = true
-            }
-            self.url = url
+            self.url = fortData.imageURL[0]
         }
-        let name = fortData.name
-        if self.name != name {
-            hasChanges = true
-        }
-        self.name = name
+        self.name = fortData.name
     }
 
-    public func addDetails(gymInfo: GymGetInfoOutProto) {
-        let name = gymInfo.name
-        let url = gymInfo.url
-        if self.url != url || self.name != name {
-            hasChanges = true
+    public func updateFromGymInfo(gymInfo: GymGetInfoOutProto) {
+        self.name = gymInfo.name
+        if !gymInfo.url.isEmpty {
+            self.url = gymInfo.url
         }
-        self.name = name
-        self.url = url
     }
 
     public func save(mysql: MySQL?=nil) throws {
@@ -334,16 +303,24 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
         } catch {
             oldGym = nil
         }
-        let mysqlStmt = MySQLStmt(mysql)
 
         if raidIsExclusive != nil && raidIsExclusive! && Gym.exRaidBossId != nil {
-            raidPokemonId = Gym.exRaidBossId!
-            raidPokemonForm = Gym.exRaidBossForm ?? 0
+            self.raidPokemonId = Gym.exRaidBossId!
+            self.raidPokemonForm = Gym.exRaidBossForm ?? 0
         }
 
-        updated = UInt32(Date().timeIntervalSince1970)
-
         let now = UInt32(Date().timeIntervalSince1970)
+
+        if oldGym != nil && !Gym.hasChanges(old: oldGym!, new: self) {
+            if self.updated! > now - 600 {
+                // if a gym is unchanged but we did see it again after 10 minutes, then save again
+                return
+            }
+        }
+        let mysqlStmt = MySQLStmt(mysql)
+
+        self.updated = now
+
         if oldGym == nil {
             let sql = """
                 INSERT INTO gym (
@@ -355,75 +332,30 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
                     power_up_end_timestamp, updated, first_seen_timestamp)
                 VALUES (
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UNIX_TIMESTAMP()
                 )
             """
-            self.updated = now
             _ = mysqlStmt.prepare(statement: sql)
             mysqlStmt.bindParam(id)
         } else {
-            if oldGym!.cellId != nil && self.cellId == nil {
-                self.cellId = oldGym!.cellId
-            }
-            if oldGym!.name != nil && self.name == nil {
-                self.name = oldGym!.name
-            }
-            if oldGym!.url != nil && self.url == nil {
-                self.url = oldGym!.url
-            }
-            if oldGym!.raidIsExclusive != nil && self.raidIsExclusive == nil {
-                self.raidIsExclusive = oldGym!.raidIsExclusive
-            }
-
-            if self.raidEndTimestamp == nil && oldGym!.raidEndTimestamp != nil {
-                self.raidEndTimestamp = oldGym!.raidEndTimestamp
-            }
-
-            guard Gym.shouldUpdate(old: oldGym!, new: self) else {
-                return
-            }
-
-            if self.raidSpawnTimestamp != nil && raidSpawnTimestamp != 0 &&
-                (
-                    oldGym!.raidLevel != self.raidLevel ||
-                    oldGym!.raidPokemonId != self.raidPokemonId ||
-                    oldGym!.raidSpawnTimestamp != self.raidSpawnTimestamp
-                ) {
-
-                let raidBattleTime = Date(timeIntervalSince1970: Double(raidBattleTimestamp ?? 0))
-                let raidEndTime = Date(timeIntervalSince1970: Double(raidEndTimestamp ?? 0))
-                let now = Date()
-
-                if raidBattleTime > now && self.raidLevel ?? 0 != 0 {
-                    WebHookController.global.addEggEvent(gym: self)
-                } else if raidEndTime > now && self.raidPokemonId ?? 0 != 0 {
-                    WebHookController.global.addRaidEvent(gym: self)
-                }
-
-            }
-            let nameSQL = name != nil ? "name = ?, " : ""
-
             let sql = """
                 UPDATE gym
-                SET lat = ?, lon = ?, \(nameSQL) url = ?, guarding_pokemon_id = ?, last_modified_timestamp = ?,
+                SET lat = ?, lon = ?, name = ?, url = ?, guarding_pokemon_id = ?, last_modified_timestamp = ?,
                     team_id = ?, raid_end_timestamp = ?, raid_spawn_timestamp = ?, raid_battle_timestamp = ?,
                     raid_pokemon_id = ?, enabled = ?, available_slots = ?, updated = UNIX_TIMESTAMP(), raid_level = ?,
                     ex_raid_eligible = ?, in_battle = ?, raid_pokemon_move_1 = ?, raid_pokemon_move_2 = ?,
                     raid_pokemon_form = ?, raid_pokemon_costume = ?, raid_pokemon_cp = ?, raid_pokemon_gender = ?,
                     raid_is_exclusive = ?, cell_id = ?, deleted = false, total_cp = ?, sponsor_id = ?, partner_id = ?,
                     raid_pokemon_evolution = ?, ar_scan_eligible = ?, power_up_points = ?, power_up_level = ?,
-                    power_up_end_timestamp = ?
+                    power_up_end_timestamp = ?, updated = ?
                 WHERE id = ?
             """
-            self.updated = now
             _ = mysqlStmt.prepare(statement: sql)
         }
 
         mysqlStmt.bindParam(lat)
         mysqlStmt.bindParam(lon)
-        if oldGym == nil || name != nil {
-            mysqlStmt.bindParam(name)
-        }
+        mysqlStmt.bindParam(name)
         mysqlStmt.bindParam(url)
         mysqlStmt.bindParam(guardPokemonId)
         mysqlStmt.bindParam(lastModifiedTimestamp)
@@ -453,6 +385,7 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
         mysqlStmt.bindParam(powerUpPoints)
         mysqlStmt.bindParam(powerUpLevel)
         mysqlStmt.bindParam(powerUpEndTimestamp)
+        mysqlStmt.bindParam(updated)
 
         if oldGym != nil {
             mysqlStmt.bindParam(id)
@@ -469,39 +402,7 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
 
         Gym.cache?.set(id: id, value: self)
 
-        if oldGym == nil {
-            WebHookController.global.addGymEvent(gym: self)
-            WebHookController.global.addGymInfoEvent(gym: self)
-            let raidBattleTime = Date(timeIntervalSince1970: Double(raidBattleTimestamp ?? 0))
-            let raidEndTime = Date(timeIntervalSince1970: Double(raidEndTimestamp ?? 0))
-            let now = Date()
-
-            if raidBattleTime > now && self.raidLevel ?? 0 != 0 {
-                WebHookController.global.addEggEvent(gym: self)
-            } else if raidEndTime > now && self.raidPokemonId ?? 0 != 0 {
-                WebHookController.global.addRaidEvent(gym: self)
-            }
-        } else {
-            if self.raidSpawnTimestamp != nil && raidSpawnTimestamp != 0 && (
-                    oldGym!.raidLevel != self.raidLevel ||
-                    oldGym!.raidPokemonId != self.raidPokemonId ||
-                    oldGym!.raidSpawnTimestamp != self.raidSpawnTimestamp) {
-                let raidBattleTime = Date(timeIntervalSince1970: Double(raidBattleTimestamp ?? 0))
-                let raidEndTime = Date(timeIntervalSince1970: Double(raidEndTimestamp ?? 0))
-                let now = Date()
-
-                if raidBattleTime > now && self.raidLevel ?? 0 != 0 {
-                    WebHookController.global.addEggEvent(gym: self)
-                } else if raidEndTime > now && self.raidPokemonId ?? 0 != 0 {
-                    WebHookController.global.addRaidEvent(gym: self)
-                }
-            }
-            if oldGym!.availableSlots != self.availableSlots ||
-               oldGym!.teamId != self.teamId ||
-               oldGym!.inBattle != self.inBattle {
-                WebHookController.global.addGymInfoEvent(gym: self)
-            }
-        }
+        Gym.createGymWebhooks(old: oldGym, new: self)
     }
 
     //  swiftlint:disable:next function_parameter_count
@@ -754,10 +655,16 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
 
     }
 
-    public static func getWithId(mysql: MySQL?=nil, id: String, withDeleted: Bool=false) throws -> Gym? {
+    public static func getWithId(mysql: MySQL? = nil, id: String, copy: Bool = false, withDeleted: Bool = false
+    ) throws -> Gym? {
 
         if let cached = cache?.get(id: id) {
-            return cached
+            // it's a reference type instance, without copying it we would modify the instance within cache
+            if copy {
+                return (cached.copy() as! Gym)
+            } else {
+                return cached
+            }
         }
 
         guard let mysql = mysql ?? DBController.global.mysql else {
@@ -1127,34 +1034,91 @@ public class Gym: JSONConvertibleObject, WebHookEvent, Hashable {
         return mysqlStmt.affectedRows()
     }
 
-    public static func shouldUpdate(old: Gym, new: Gym) -> Bool {
-        if old.hasChanges {
-            old.hasChanges = false
-            return true
-        }
-        return
-            new.lastModifiedTimestamp != old.lastModifiedTimestamp ||
-            new.name != old.name ||
-            new.url != old.url ||
-            new.enabled != old.enabled ||
-            new.raidEndTimestamp != old.raidEndTimestamp ||
-            new.raidPokemonId != old.raidPokemonId ||
-            new.teamId != old.teamId ||
-            new.guardPokemonId != old.guardPokemonId ||
-            new.availableSlots != old.availableSlots ||
-            new.totalCp != old.totalCp ||
-            new.exRaidEligible != old.exRaidEligible ||
-            new.sponsorId != old.sponsorId ||
-            new.partnerId != old.partnerId ||
-            new.arScanEligible != old.arScanEligible ||
-            new.powerUpPoints != old.powerUpPoints ||
-            new.powerUpEndTimestamp != old.powerUpEndTimestamp ||
-            fabs(new.lat - old.lat) >= 0.000001 ||
-            fabs(new.lon - old.lon) >= 0.000001
-    }
-
     public static func == (lhs: Gym, rhs: Gym) -> Bool {
         return lhs.id == rhs.id
     }
 
+    public func copy(with zone: NSZone? = nil) -> Any {
+        Gym(id: id, lat: lat, lon: lon, name: name, url: url, guardPokemonId: guardPokemonId, enabled: enabled,
+            lastModifiedTimestamp: lastModifiedTimestamp, teamId: teamId, raidEndTimestamp: raidEndTimestamp,
+            raidSpawnTimestamp: raidSpawnTimestamp, raidBattleTimestamp: raidBattleTimestamp,
+            raidPokemonId: raidPokemonId, raidLevel: raidLevel, availableSlots: availableSlots, updated: updated,
+            exRaidEligible: exRaidEligible, inBattle: inBattle, raidPokemonMove1: raidPokemonMove1,
+            raidPokemonMove2: raidPokemonMove2, raidPokemonForm: raidPokemonForm,
+            raidPokemonCostume: raidPokemonCostume, raidPokemonCp: raidPokemonCp, raidPokemonGender: raidPokemonGender,
+            raidPokemonEvolution: raidPokemonEvolution, raidIsExclusive: raidIsExclusive, cellId: cellId,
+            totalCp: totalCp, sponsorId: sponsorId, partnerId: partnerId, arScanEligible: arScanEligible,
+            powerUpPoints: powerUpPoints, powerUpLevel: powerUpLevel, powerUpEndTimestamp: powerUpEndTimestamp)
+    }
+
+    // =================================================================================================================
+    //  HELPER METHODS
+    // =================================================================================================================
+
+    private static func createGymWebhooks(old: Gym?, new: Gym) {
+        if old == nil ||
+               old!.availableSlots != new.availableSlots || old!.teamId != new.teamId || old!.inBattle != new.inBattle {
+            WebHookController.global.addGymEvent(gym: new)
+        }
+        if new.raidSpawnTimestamp ?? 0 > 0 && (
+            old == nil || old!.raidLevel != new.raidLevel ||
+            old!.raidPokemonId != new.raidPokemonId ||
+            old!.raidSpawnTimestamp != new.raidSpawnTimestamp) {
+            let raidBattleTime = Date(timeIntervalSince1970: Double(new.raidBattleTimestamp ?? 0))
+            let raidEndTime = Date(timeIntervalSince1970: Double(new.raidEndTimestamp ?? 0))
+            let now = Date()
+
+            if raidBattleTime > now && new.raidLevel ?? 0 != 0 {
+                WebHookController.global.addEggEvent(gym: new)
+            } else if raidEndTime > now && new.raidPokemonId ?? 0 != 0 {
+                WebHookController.global.addRaidEvent(gym: new)
+            }
+        }
+
+    }
+
+    private func calculatePowerUpPoints(fortData: PokemonFortProto, now: UInt32) -> (UInt16, UInt32?) {
+        let powerUpLevelExpirationMs = UInt32(fortData.powerUpLevelExpirationMs / 1000)
+        let powerUpPoints = fortData.powerUpProgressPoints
+        var powerUpLevel: UInt16 = 0
+        var powerUpEndTimestamp: UInt32?
+        if powerUpPoints < 50 {
+            powerUpLevel = 0
+        } else if powerUpPoints < 100 && powerUpLevelExpirationMs > now {
+            powerUpLevel = 1
+            powerUpEndTimestamp = powerUpLevelExpirationMs
+        } else if powerUpPoints < 150 && powerUpLevelExpirationMs > now {
+            powerUpLevel = 2
+            powerUpEndTimestamp = powerUpLevelExpirationMs
+        } else if powerUpLevelExpirationMs > now {
+            powerUpLevel = 3
+            powerUpEndTimestamp = powerUpLevelExpirationMs
+        } else {
+            powerUpLevel = 0
+        }
+        return (powerUpLevel, powerUpEndTimestamp)
+    }
+
+    private static func hasChanges(old: Gym, new: Gym) -> Bool {
+        return
+            new.lastModifiedTimestamp != old.lastModifiedTimestamp ||
+                new.name != old.name ||
+                new.url != old.url ||
+                new.enabled != old.enabled ||
+                new.raidEndTimestamp != old.raidEndTimestamp ||
+                new.raidPokemonId != old.raidPokemonId ||
+                new.teamId != old.teamId ||
+                new.guardPokemonId != old.guardPokemonId ||
+                new.availableSlots != old.availableSlots ||
+                new.totalCp != old.totalCp ||
+                new.exRaidEligible != old.exRaidEligible ||
+                new.sponsorId != old.sponsorId ||
+                new.partnerId != old.partnerId ||
+                new.arScanEligible != old.arScanEligible ||
+                new.powerUpLevel != old.powerUpLevel ||
+                new.powerUpPoints != old.powerUpPoints ||
+                new.powerUpEndTimestamp != old.powerUpEndTimestamp ||
+                fabs(new.lat - old.lat) >= 0.000001 ||
+                fabs(new.lon - old.lon) >= 0.000001
+    }
 }

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -1091,23 +1091,23 @@ public class Gym: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
     private static func hasChanges(old: Gym, new: Gym) -> Bool {
         return
             new.lastModifiedTimestamp != old.lastModifiedTimestamp ||
-                new.name != old.name ||
-                new.url != old.url ||
-                new.enabled != old.enabled ||
-                new.raidEndTimestamp != old.raidEndTimestamp ||
-                new.raidPokemonId != old.raidPokemonId ||
-                new.teamId != old.teamId ||
-                new.guardPokemonId != old.guardPokemonId ||
-                new.availableSlots != old.availableSlots ||
-                new.totalCp != old.totalCp ||
-                new.exRaidEligible != old.exRaidEligible ||
-                new.sponsorId != old.sponsorId ||
-                new.partnerId != old.partnerId ||
-                new.arScanEligible != old.arScanEligible ||
-                new.powerUpLevel != old.powerUpLevel ||
-                new.powerUpPoints != old.powerUpPoints ||
-                new.powerUpEndTimestamp != old.powerUpEndTimestamp ||
-                fabs(new.lat - old.lat) >= 0.000001 ||
-                fabs(new.lon - old.lon) >= 0.000001
+            new.name != old.name ||
+            new.url != old.url ||
+            new.enabled != old.enabled ||
+            new.raidEndTimestamp != old.raidEndTimestamp ||
+            new.raidPokemonId != old.raidPokemonId ||
+            new.teamId != old.teamId ||
+            new.guardPokemonId != old.guardPokemonId ||
+            new.availableSlots != old.availableSlots ||
+            new.totalCp != old.totalCp ||
+            new.exRaidEligible != old.exRaidEligible ||
+            new.sponsorId != old.sponsorId ||
+            new.partnerId != old.partnerId ||
+            new.arScanEligible != old.arScanEligible ||
+            new.powerUpLevel != old.powerUpLevel ||
+            new.powerUpPoints != old.powerUpPoints ||
+            new.powerUpEndTimestamp != old.powerUpEndTimestamp ||
+            fabs(new.lat - old.lat) >= 0.000001 ||
+            fabs(new.lon - old.lon) >= 0.000001
     }
 }

--- a/Sources/RealDeviceMapLib/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokemon.swift
@@ -560,7 +560,6 @@ public class Pokemon: JSONConvertibleObject, NSCopying, WebHookEvent, Equatable,
                 self.expireTimestampVerified = oldPokemonNoneEvent.expireTimestampVerified
             }
         }
-
         if oldPokemon == nil {
             var sql = """
                 INSERT INTO pokemon (
@@ -732,7 +731,7 @@ public class Pokemon: JSONConvertibleObject, NSCopying, WebHookEvent, Equatable,
         let uuid = Pokemon.getUuid(id: id, isEvent: isEvent)
         Pokemon.cache?.set(id: uuid, value: self)
 
-        createPokemonWebhooks(old: oldPokemon, new: self)
+        Pokemon.createPokemonWebhooks(old: oldPokemon, new: self)
         if oldPokemon == nil {
             InstanceController.global.gotPokemon(pokemon: self)
             if self.atkIv != nil {
@@ -955,7 +954,11 @@ public class Pokemon: JSONConvertibleObject, NSCopying, WebHookEvent, Equatable,
         let uuid = Pokemon.getUuid(id: id, isEvent: isEvent)
         if let cached = cache?.get(id: uuid) {
             // it's a reference type instance, without copying it we would modify the instance within cache
-            return (cached.copy() as! Pokemon)
+            if copy {
+                return (cached.copy() as! Pokemon)
+            } else {
+                return cached
+            }
         }
 
         guard let mysql = mysql ?? DBController.global.mysql else {
@@ -1096,21 +1099,20 @@ public class Pokemon: JSONConvertibleObject, NSCopying, WebHookEvent, Equatable,
     }
 
     public func copy(with zone: NSZone? = nil) -> Any {
-        let copy = Pokemon(id: id, pokemonId: pokemonId, lat: lat, lon: lon, spawnId: spawnId,
+        Pokemon(id: id, pokemonId: pokemonId, lat: lat, lon: lon, spawnId: spawnId,
             expireTimestamp: expireTimestamp, atkIv: atkIv, defIv: defIv, staIv: staIv, move1: move1, move2: move2,
             gender: gender, form: form, cp: cp, level: level, weight: weight, costume: costume, size: size,
             capture1: capture1, capture2: capture2, capture3: capture3, displayPokemonId: displayPokemonId,
             isDitto: isDitto, weather: weather, shiny: shiny, username: username, pokestopId: pokestopId,
             firstSeenTimestamp: firstSeenTimestamp, updated: updated, changed: changed, cellId: cellId,
             expireTimestampVerified: expireTimestampVerified, pvp: pvp, isEvent: isEvent, seenType: seenType)
-        return copy
     }
 
     // =================================================================================================================
     //  HELPER METHODS
     // =================================================================================================================
 
-    private func createPokemonWebhooks(old: Pokemon?, new: Pokemon) {
+    private static func createPokemonWebhooks(old: Pokemon?, new: Pokemon) {
         if old == nil ||
             old!.pokemonId != new.pokemonId ||
             old!.weather != new.weather ||
@@ -1425,5 +1427,4 @@ public class Pokemon: JSONConvertibleObject, NSCopying, WebHookEvent, Equatable,
             fabs(new.lat - old.lat) >= 0.000001 ||
             fabs(new.lon - old.lon) >= 0.000001
     }
-
 }

--- a/Sources/RealDeviceMapLib/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokemon.swift
@@ -1221,10 +1221,10 @@ public class Pokemon: JSONConvertibleObject, NSCopying, WebHookEvent, Equatable,
         self.gender = display.gender.rawValue.toUInt8()
         self.form = display.form.rawValue.toUInt16()
         self.costume = display.costume.rawValue.toUInt8()
+        setWeather(weather: display.weatherBoostedCondition.rawValue.toUInt8())
         if self.pokemonId == 0 || !self.isDitto {
             self.pokemonId = pokemonId
         }
-        setWeather(weather: display.weatherBoostedCondition.rawValue.toUInt8())
     }
 
     private func setWeather(weather: UInt8) {

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -133,8 +133,6 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
     var lureExpireTimestamp: UInt32?
     var lastModifiedTimestamp: UInt32?
     var name: String?
-    var description: String?
-    var promoDescription: String?
     var url: String?
     var sponsorId: UInt16? // unused
     var partnerId: String?
@@ -261,18 +259,16 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
             self.url = fortData.imageURL[0]
         }
         self.name = fortData.name
-        if !fortData.description_p.isEmpty {
-            self.description = fortData.description_p
-        } else {
-            self.description = nil
-        }
+//        if !fortData.description_p.isEmpty {
+//            self.description = fortData.description_p
+//        } else {
+//            self.description = nil
+//        }
 
-        if fortData.promoDescription.count != 0 {
-            self.promoDescription = fortData.promoDescription.jsonEncodeForceTry()
-            Log.debug(message: "[POKESTOP] Pokestop \(id) found with promo: \(promoDescription ?? "")")
-        } else {
-            self.promoDescription = nil
-        }
+//        if fortData.promoDescription.count != 0 {
+//            let promoDescription = fortData.promoDescription.jsonEncodeForceTry()
+//            Log.debug(message: "[POKESTOP] Pokestop \(id) found with promo: \(promoDescription ?? "")")
+//        }
     }
 
     public func updatePokestopFromQuestProto(questData: ClientQuestProto, hasARQuest: Bool) {

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -220,7 +220,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
         self.lon = fortData.longitude
         self.enabled = fortData.enabled
         self.arScanEligible = fortData.isArScanEligible
-        self.partnerId = fortData.partnerID != "" ? fortData.partnerID : nil
+        self.partnerId = fortData.partnerID.isEmpty ? nil : fortData.partnerID
 
         (self.powerUpLevel, self.powerUpEndTimestamp) = fortData.calculatePowerUpLevel(now: now)
 
@@ -241,7 +241,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
                 }
             }
         }
-        if fortData.imageURL != "" {
+        if !fortData.imageURL.isEmpty {
             self.url = fortData.imageURL
         }
         self.cellId = cellId
@@ -261,11 +261,15 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
             self.url = fortData.imageURL[0]
         }
         self.name = fortData.name
-        self.description = fortData.description_p
+        if !fortData.description_p.isEmpty {
+            self.description = fortData.description_p
+        } else {
+            self.description = nil
+        }
 
         if fortData.promoDescription.count != 0 {
             self.promoDescription = fortData.promoDescription.jsonEncodeForceTry()
-            Log.debug(message: "[POKESTOP] \(id) with promo: \(promoDescription ?? "")")
+            Log.debug(message: "[POKESTOP] Pokestop \(id) found with promo: \(promoDescription ?? "")")
         } else {
             self.promoDescription = nil
         }

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -222,7 +222,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
         self.arScanEligible = fortData.isArScanEligible
         self.partnerId = fortData.partnerID != "" ? fortData.partnerID : nil
 
-        (self.powerUpLevel, self.powerUpEndTimestamp) = fortData.calculatePowerUpPoints(now: now)
+        (self.powerUpLevel, self.powerUpEndTimestamp) = fortData.calculatePowerUpLevel(now: now)
 
         let lastModifiedTimestamp = UInt32(fortData.lastModifiedMs / 1000)
         self.lastModifiedTimestamp = lastModifiedTimestamp

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -1379,22 +1379,22 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
     private static func hasChanges(old: Pokestop, new: Pokestop) -> Bool {
         return
             new.lastModifiedTimestamp != old.lastModifiedTimestamp ||
-                new.lureExpireTimestamp != old.lureExpireTimestamp ||
-                new.lureId != old.lureId ||
-                new.incidents.count != old.incidents.count ||
-                new.name != old.name ||
-                new.url != old.url ||
-                new.arScanEligible != old.arScanEligible ||
-                new.powerUpLevel != old.powerUpLevel ||
-                new.powerUpPoints != old.powerUpPoints ||
-                new.powerUpEndTimestamp != old.powerUpEndTimestamp ||
-                new.questTemplate != old.questTemplate ||
-                new.alternativeQuestTemplate != old.alternativeQuestTemplate ||
-                new.enabled != old.enabled ||
-                new.sponsorId != old.sponsorId ||
-                new.partnerId != old.partnerId ||
-                fabs(new.lat - old.lat) >= 0.000001 ||
-                fabs(new.lon - old.lon) >= 0.000001
+            new.lureExpireTimestamp != old.lureExpireTimestamp ||
+            new.lureId != old.lureId ||
+            new.incidents.count != old.incidents.count ||
+            new.name != old.name ||
+            new.url != old.url ||
+            new.arScanEligible != old.arScanEligible ||
+            new.powerUpLevel != old.powerUpLevel ||
+            new.powerUpPoints != old.powerUpPoints ||
+            new.powerUpEndTimestamp != old.powerUpEndTimestamp ||
+            new.questTemplate != old.questTemplate ||
+            new.alternativeQuestTemplate != old.alternativeQuestTemplate ||
+            new.enabled != old.enabled ||
+            new.sponsorId != old.sponsorId ||
+            new.partnerId != old.partnerId ||
+            fabs(new.lat - old.lat) >= 0.000001 ||
+            fabs(new.lon - old.lon) >= 0.000001
     }
 
     private static func flattenCoords(area: String) -> String {

--- a/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
@@ -248,7 +248,7 @@ public class WebRequestHandler {
                         }
                     }
                     if request.pathComponents[1] == "@pokestop" {
-                        if let pokestop = try Pokestop.getWithId(id: id) {
+                        if let pokestop = try Pokestop.getWithId(id: id, copy: true) {
                             if !perms.contains(.viewMapLure) {
                                 pokestop.lureId = nil
                                 pokestop.lureExpireTimestamp = nil
@@ -279,7 +279,7 @@ public class WebRequestHandler {
                         }
                     }
                     if request.pathComponents[1] == "@gym" {
-                        if let gym = try Gym.getWithId(id: id) {
+                        if let gym = try Gym.getWithId(id: id, copy: true) {
                             if !perms.contains(.viewMapRaid) {
                                 gym.raidEndTimestamp = nil
                                 gym.raidSpawnTimestamp = nil

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -893,7 +893,7 @@ public class WebHookRequestHandler {
             if enableClearing {
                 let lastCleared = clearingLock.doWithLock { clearingTimestamp }
                 if lastCleared < timestamp - 900 {
-                    Log.debug("TMP clearing old gyms/stops now, if there are")
+                    Log.debug(message: "TMP clearing old gyms/stops now, if there are")
                     clearingLock.doWithLock {
                         for (cellId, gymIds) in gymIdsPerCellLookup {
                             if let cleared = try? Gym.clearOld(mysql: mysql, ids: gymIds, cellId: cellId),

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -887,7 +887,7 @@ public class WebHookRequestHandler {
 
             if enableClearing {
                 for (cellId, gymIds) in gymIdsPerCell {
-                    let cachedCell = Cell.cache.get(id: cellId.toString())
+                    let cachedCell = Cell.cache?.get(id: cellId.toString())
                     if cachedCell?.gymCount != gymIds.count {
                         Log.debug(message: "[CLEARING] clear old gyms: " +
                             "\(cachedCell?.gymCount ?? 0) != \(gymIds.count)")
@@ -900,7 +900,7 @@ public class WebHookRequestHandler {
                     cachedCell?.gymCount = gymIds.count
                 }
                 for (cellId, stopIds) in stopsIdsPerCell {
-                    let cachedCell = Cell.cache.get(id: cellId.toString())
+                    let cachedCell = Cell.cache?.get(id: cellId.toString())
                     if cachedCell?.stopCount != stopIds.count {
                         Log.debug(message: "[CLEARING] clear old stops: " +
                             "\(cachedCell?.stopCount ?? 0) != \(stopIds.count)")

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -893,6 +893,7 @@ public class WebHookRequestHandler {
             if enableClearing {
                 let lastCleared = clearingLock.doWithLock { clearingTimestamp }
                 if lastCleared < timestamp - 900 {
+                    Log.debug("TMP clearing old gyms/stops now, if there are")
                     clearingLock.doWithLock {
                         for (cellId, gymIds) in gymIdsPerCellLookup {
                             if let cleared = try? Gym.clearOld(mysql: mysql, ids: gymIds, cellId: cellId),

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -844,7 +844,6 @@ public class WebHookRequestHandler {
                 let start = Date()
                 for encounter in encounters {
                     let id = encounter.pokemon.encounterID.description
-                    Log.debug(message: "[WebHookRequestHandler] found encounter \(id)")
                     let pokemon = (try? Pokemon.getWithId(mysql: mysql, id: id, copy: true, isEvent: isEvent))
                         ?? Pokemon()
                     pokemon.updateFromEncounterProto(mysql: mysql, encounterData: encounter,

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -891,7 +891,7 @@ public class WebHookRequestHandler {
                 for (cellId, gymIds) in gymIdsPerCell {
                     let cachedCell = Cell.cache?.get(id: cellId.toString())
                     if cachedCell?.gymCount != gymIds.count {
-                        Log.debug(message: "[CLEARING] clear old gyms: " +
+                        Log.debug(message: "[WebHookRequestHandler] Clearing old gyms in \(cellId): " +
                             "\(cachedCell?.gymCount ?? 0) != \(gymIds.count)")
                         if let cleared = try? Gym.clearOld(mysql: mysql, ids: gymIds, cellId: cellId),
                            cleared != 0 {
@@ -904,7 +904,7 @@ public class WebHookRequestHandler {
                 for (cellId, stopIds) in stopsIdsPerCell {
                     let cachedCell = Cell.cache?.get(id: cellId.toString())
                     if cachedCell?.stopCount != stopIds.count {
-                        Log.debug(message: "[CLEARING] clear old stops: " +
+                        Log.debug(message: "[WebHookRequestHandler] Clearing old stops in \(cellId): " +
                             "\(cachedCell?.stopCount ?? 0) != \(stopIds.count)")
                         if let cleared = try? Pokestop.clearOld(mysql: mysql, ids: stopIds, cellId: cellId),
                            cleared != 0 {

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -58,12 +58,14 @@ public func setupRealDeviceMap() {
             "[MAIN] Starting Memory Cache with interval \(memoryCacheClearInterval) " +
             "and keep time \(memoryCacheKeepTime)"
         )
+        Pokemon.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime,
+            extendTtlOnAccess: false)
         Pokestop.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
-        Pokemon.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
         Gym.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
         SpawnPoint.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
         Weather.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
         Incident.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
+        Cell.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
     } else {
         Log.info(message: "[MAIN] Memory Cache deactivated")
     }

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -59,7 +59,7 @@ public func setupRealDeviceMap() {
             "and keep time \(memoryCacheKeepTime)"
         )
         Pokemon.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime,
-            extendTtlOnAccess: false)
+            extendTtlOnHit: false)
         Pokestop.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
         Gym.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
         SpawnPoint.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)


### PR DESCRIPTION
- rework fort insert / update logic of gyms / pokestops (same like pokemon)
- lures should not be extended anymore, when invasion occurs during lured is already active
- improve the clearing of forts, actually the query is very exhaustive -> use s2cell cache to store stop and gym count of each cell to compare before deleting old stops/gyms
- Pokemon cache TTL is not extended anymore on hit (every pokemon is maximum 60 minutes available, don't extend cache ttl for that key anymore, should decrease also mem size)
- updating forts at least every 10 minutes if unchanged

closes #393
is implemented in that PR, thanks a lot for `extendTtl` functionality. This is very useful for pokemon