### PR TITLE
Sync Development into Master

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(name: "S2Geometry", url: "https://github.com/123FLO321/S2Geometry.git", from: "0.5.0"),
         .package(name: "Regex", url: "https://github.com/crossroadlabs/Regex.git", from: "1.2.0"),
         .package(name: "swift-backtrace", url: "https://github.com/swift-server/swift-backtrace.git", from: "1.3.3"),
-        .package(name: "POGOProtos", url: "https://github.com/123FLO321/POGOProtos-Swift.git", .upToNextMinor(from: "2.17.0"))
+        .package(name: "POGOProtos", url: "https://github.com/123FLO321/POGOProtos-Swift.git", .upToNextMinor(from: "2.18.0"))
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ It also includes a basic proof of concept Instance and Device Manager.
 
 ## Feature Requests
 
-[![Feature Requests](http://feathub.com/123FLO321/RealDeviceMap?format=svg)](http://feathub.com/123FLO321/RealDeviceMap)
+[Feature Requests](https://github.com/RealDeviceMap/RealDeviceMap/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
 
-Questions? Ask as in Discord: https://discord.gg/q2aXaGP
+Questions? Ask as in [Discord](https://discord.gg/q2aXaGP)

--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2255,11 +2255,10 @@ public class ApiRequestHandler {
 
         if setGymName, perms.contains(.admin), let id = gymId, let name = gymName {
             do {
-                guard let oldGym = try Gym.getWithId(id: id) else {
+                guard let oldGym = try Gym.getWithId(id: id, copy: true) else {
                     return response.respondWithError(status: .custom(code: 404, message: "Gym not found"))
                 }
                 oldGym.name = name
-                oldGym.hasChanges = true
                 try oldGym.save()
                 response.respondWithOk()
             } catch {
@@ -2267,11 +2266,10 @@ public class ApiRequestHandler {
             }
         } else if setPokestopName, perms.contains(.admin), let id = pokestopId, let name = pokestopName {
            do {
-               guard let oldPokestop = try Pokestop.getWithId(id: id) else {
+               guard let oldPokestop = try Pokestop.getWithId(id: id, copy: true) else {
                    return response.respondWithError(status: .custom(code: 404, message: "Pokestop not found"))
                }
                oldPokestop.name = name
-               oldPokestop.hasChanges = true
                try oldPokestop.save()
                response.respondWithOk()
            } catch {

--- a/Sources/RealDeviceMapLib/Controller/DBController.swift
+++ b/Sources/RealDeviceMapLib/Controller/DBController.swift
@@ -142,7 +142,10 @@ public class DBController {
 
         setup()
 
-        Log.info(message: "[DBController] Done")
+        Log.info(message: "[DBController] Done initalizing")
+        Log.info(message: "[DBController] DB Name: \(database)")
+        Log.info(message: "[DBController] DB Host: \(host)")
+        Log.info(message: "[DBController] DB Port: \(dbPort)")
     }
 
     private func setup() {
@@ -255,7 +258,9 @@ public class DBController {
     }
 
     private func backup(mysql: MySQL, fromVersion: Int, toVersion: Int) {
-        if fromVersion < toVersion && ConfigLoader.global.getConfig(type: .dbBackup) {
+        let backupEnabled: Bool = ConfigLoader.global.getConfig(type: .dbBackup)
+        Log.info(message: "[DBController] DB backups enabled: \(backupEnabled)")
+        if fromVersion < toVersion && backupEnabled {
             Log.info(message: "[DBController] Creating Backup of database for version \(fromVersion)")
             let uuidString = Foundation.UUID().uuidString
             let backupsDir = Dir("\(Dir.projectroot)/backups")
@@ -274,6 +279,7 @@ public class DBController {
                 "instance": true,
                 "metadata": true,
                 "pokemon": true,
+                "pokemon_iv_stats": false,
                 "pokemon_stats": false,
                 "pokemon_shiny_stats": false,
                 "pokemon_hundo_stats": false,
@@ -286,7 +292,8 @@ public class DBController {
                 "token": true,
                 "user": true,
                 "weather": true,
-                "web_session": true
+                "web_session": true,
+                "webhook": true
             ]
 
             var tablesShema = ""

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/AutoInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/AutoInstanceController.swift
@@ -532,7 +532,7 @@ class AutoInstanceController: InstanceControllerProto {
                             accountsLock.lock()
                             if accounts[uuid] == nil {
                                 newUsername = account?.username
-                                accounts[uuid] = account?.username
+                                accounts[uuid] = newUsername
                                 Log.debug(
                                     message: "[AutoInstanceController] [\(name)] [\(uuid)] Over Logout Delay. " +
                                              "Switching Account from \(username ?? "?") to \(newUsername ?? "?")"

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleInstanceController.swift
@@ -35,6 +35,7 @@ class CircleInstanceController: InstanceControllerProto {
     private var currentUuidIndexes: [String: Int]
     private var currentUuidSeenTime: [String: Date]
     public let useRwForRaid: Bool = ConfigLoader.global.getConfig(type: .accUseRwForRaid)
+    public let useRwForPokes: Bool = ConfigLoader.global.getConfig(type: .accUseRwForPokes)
 
     init(name: String, coords: [Coord], type: CircleType, minLevel: UInt8, maxLevel: UInt8,
          accountGroup: String?, isEvent: Bool) {
@@ -206,7 +207,7 @@ class CircleInstanceController: InstanceControllerProto {
                 mysql: mysql,
                 minLevel: minLevel,
                 maxLevel: maxLevel,
-                ignoringWarning: false,
+                ignoringWarning: useRwForPokes,
                 spins: nil,
                 noCooldown: false,
                 device: uuid,
@@ -231,7 +232,7 @@ class CircleInstanceController: InstanceControllerProto {
         case .pokemon, .smartPokemon:
             return account.level >= minLevel &&
                 account.level <= maxLevel &&
-                account.isValid(group: accountGroup)
+                account.isValid(ignoringWarning: useRwForPokes, group: accountGroup)
         case .raid:
             return account.level >= minLevel &&
                 account.level <= maxLevel &&

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/IVInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/IVInstanceController.swift
@@ -129,7 +129,7 @@ class IVInstanceController: InstanceControllerProto {
         let pokemon = pokemonQueue.removeFirst()
         pokemonLock.unlock()
 
-        if UInt32(Date().timeIntervalSince1970) - (pokemon.firstSeenTimestamp ?? 1) >= 600 {
+        if UInt32(Date().timeIntervalSince1970) - (pokemon.firstSeenTimestamp) >= 600 {
             return getTask(mysql: mysql, uuid: uuid, username: username, account: account, timestamp: timestamp)
         }
 

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/InstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/InstanceController.swift
@@ -356,7 +356,7 @@ public class InstanceController {
         if let instanceController = getInstanceController(deviceUUID: deviceUUID) {
             return try instanceController.getAccount(mysql: mysql, uuid: deviceUUID)
         }
-        return try Account.getNewAccount(minLevel: 0, maxLevel: 29, device: deviceUUID)
+        return try Account.getNewAccount(minLevel: 0, maxLevel: 30, device: deviceUUID)
     }
 
     public func accountValid(deviceUUID: String, account: Account) -> Bool {

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/LevelingInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/LevelingInstanceController.swift
@@ -184,8 +184,8 @@ class LevelingInstanceController: InstanceControllerProto {
         unspunLoop: for stop in unspunPokestops {
             let coord = Coord(lat: stop.latitude, lon: stop.longitude)
             for last in exclude {
-                // MARK: Revert back to 40m once reverted ingame
-                if coord.distance(to: last) <= 80 {
+                let spinDistance = Double(ConfigLoader.global.getConfig(type: .spinDistance) as Int)
+                if coord.distance(to: last) <= spinDistance {
                     continue unspunLoop
                 }
             }

--- a/Sources/RealDeviceMapLib/Controller/WebHookController.swift
+++ b/Sources/RealDeviceMapLib/Controller/WebHookController.swift
@@ -18,6 +18,8 @@ public class WebHookController {
     private init() {
         timeout = ConfigLoader.global.getConfig(type: .webhookTimeout)
         connectTimeout = ConfigLoader.global.getConfig(type: .webhookConnectTimeout)
+        Log.info(message: "[WebHookController] Webhook Endpoint Timeout: \(timeout)")
+        Log.info(message: "[WebHookController] Webhook Connection Timeout: \(connectTimeout)")
     }
 
     public private(set) static var global = WebHookController()

--- a/Sources/RealDeviceMapLib/Controller/WebHookController.swift
+++ b/Sources/RealDeviceMapLib/Controller/WebHookController.swift
@@ -405,7 +405,7 @@ public class WebHookController {
     }
 
     private func sendEvents(events: [[String: Any]], url: String) {
-        Log.debug(message: "[WebHookController] Sending \(events.count) events to" +
+        Log.debug(message: "[WebHookController] Sending \(events.count) event(s) to " +
             "\(webhooks.count) endpoints")
         guard let body = try? events.jsonEncodedString() else {
             Log.error(message: "[WebHookController] Failed to parse events into json string")

--- a/Sources/RealDeviceMapLib/Controller/WebHookController.swift
+++ b/Sources/RealDeviceMapLib/Controller/WebHookController.swift
@@ -44,8 +44,6 @@ public class WebHookController {
     private var alternativeQuestEvents = [String: Pokestop]()
     private var gymEventLock = Threading.Lock()
     private var gymEvents = [String: Gym]()
-    private var gymInfoEventLock = Threading.Lock()
-    private var gymInfoEvents = [String: Gym]()
     private var eggEventLock = Threading.Lock()
     private var eggEvents = [String: Gym]()
     private var raidEventLock = Threading.Lock()
@@ -94,12 +92,6 @@ public class WebHookController {
     public func addGymEvent(gym: Gym) {
         if !self.webhooks.isEmpty && self.types.contains(.gym) {
             gymEventLock.doWithLock { gymEvents[gym.id] = gym }
-        }
-    }
-
-    public func addGymInfoEvent(gym: Gym) {
-        if !self.webhooks.isEmpty && self.types.contains(.gym) {
-            gymInfoEventLock.doWithLock { gymInfoEvents[gym.id] = gym }
         }
     }
 
@@ -171,7 +163,6 @@ public class WebHookController {
                         var questEvents = [String: Pokestop]()
                         var alternativeQuestEvents = [String: Pokestop]()
                         var gymEvents = [String: Gym]()
-                        var gymInfoEvents = [String: Gym]()
                         var eggEvents = [String: Gym]()
                         var raidEvents = [String: Gym]()
                         var weatherEvents = [Int64: Weather]()
@@ -210,11 +201,6 @@ public class WebHookController {
                         self.gymEventLock.doWithLock {
                             gymEvents = self.gymEvents
                             self.gymEvents = [String: Gym]()
-                        }
-
-                        self.gymInfoEventLock.doWithLock {
-                            gymInfoEvents = self.gymInfoEvents
-                            self.gymInfoEvents = [String: Gym]()
                         }
 
                         self.raidEventLock.doWithLock {
@@ -330,15 +316,6 @@ public class WebHookController {
                                             continue
                                         }
                                         events.append(gym.getWebhookValues(type: WebhookType.gym.rawValue))
-                                    }
-                                }
-                                for (_, gymInfo) in gymInfoEvents {
-                                    if area.isEmpty ||
-                                           self.inPolygon(lat: gymInfo.lat, lon: gymInfo.lon, multiPolygon: polygon) {
-                                        if gymIDs.contains(Int(gymInfo.teamId ?? 0)) {
-                                            continue
-                                        }
-                                        events.append(gymInfo.getWebhookValues(type: "gym-info"))
                                     }
                                 }
                             }

--- a/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
+++ b/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
@@ -1,7 +1,7 @@
 //
 // Created by Fabio S. on 21.05.22.
 //
-//  swiftlint:disable superfluous_disable_command file_length force_cast
+//  swiftlint:disable superfluous_disable_command file_length force_cast type_body_length
 
 import Foundation
 import PerfectLib
@@ -22,7 +22,8 @@ public class ConfigLoader {
         "PVP_DEFAULT_RANK", "PVP_LITTLE_FILTER", "PVP_GREAT_FILTER", "PVP_ULTRA_FILTER", "PVP_LEVEL_CAPS",
         "USE_RW_FOR_QUEST", "USE_RW_FOR_RAID", "NO_GENERATE_IMAGES", "NO_PVP", "NO_IV_WEATHER_CLEARING",
         "NO_CELL_POKEMON", "SAVE_SPAWNPOINT_LASTSEEN", "NO_MEMORY_CACHE", "NO_BACKUP", "NO_REQUIRE_ACCOUNT",
-        "SCAN_LURE_ENCOUNTER"
+        "SCAN_LURE_ENCOUNTER", "QUEST_RETRY_LIMIT", "SPIN_DISTANCE", "ALLOW_AR_QUESTS", "STOP_ALL_BOOTSTRAPPING",
+        "USE_RW_FOR_POKES"
     ]
 
     private init() {
@@ -125,6 +126,16 @@ public class ConfigLoader {
             ?? defaultConfig.application.webhook.endpointTimeout.value()!
         case .webhookConnectTimeout: return localConfig.application.webhook.endpointConnectTimeout.value()
             ?? defaultConfig.application.webhook.endpointConnectTimeout.value()!
+        case .allowARQuests: return localConfig.application.quest.allowARQuests.value()
+            ?? defaultConfig.application.quest.allowARQuests.value()!
+        case .stopAllBootstrapping: return localConfig.application.stopAllBootstrapping.value()
+            ?? defaultConfig.application.stopAllBootstrapping.value()!
+        case .accUseRwForPokes: return localConfig.application.account.useRwForPokes.value()
+            ?? defaultConfig.application.account.useRwForPokes.value()!
+        case .questRetryLimit: return localConfig.application.quest.questRetryLimit.value()
+            ?? defaultConfig.application.quest.questRetryLimit.value()!
+        case .spinDistance: return localConfig.application.quest.spinDistance.value()
+            ?? defaultConfig.application.quest.spinDistance.value()!
         }
     }
 
@@ -169,6 +180,11 @@ public class ConfigLoader {
         case .pvpFilterUltraMinCP: return castValue(value: value)
         case .webhookTimeout: return castValue(value: value)
         case .webhookConnectTimeout: return castValue(value: value)
+        case .allowARQuests: return true as! T // ALLOW_AR_QUESTS
+        case .stopAllBootstrapping: return true as! T // STOP_ALL_BOOTSTRAPPING
+        case .accUseRwForPokes: return false as! T // USE_RW_FOR_POKES
+        case .questRetryLimit: return castValue(value: value) // QUEST_RETRY_LIMIT
+        case .spinDistance: return castValue(value: value) // SPIN_DISTANCE
         }
     }
 
@@ -181,6 +197,8 @@ public class ConfigLoader {
             return Double(value.trimmingCharacters(in: .whitespaces)) as! T
         } else if T.self == Bool.self {
             return Bool(value.trimmingCharacters(in: .whitespaces)) as! T
+        } else if T.self == UInt8.self {
+            return UInt8(value.trimmingCharacters(in: .whitespaces)) as! T
         } else {
             fatalError()
         }
@@ -225,6 +243,11 @@ public class ConfigLoader {
         case pvpFilterUltraMinCP = "PVP_ULTRA_FILTER"
         case webhookTimeout = "WEBHOOK_ENDPOINT_TIMEOUT"
         case webhookConnectTimeout = "WEBHOOK_ENDPOINT_CONNECT_TIMEOUT"
+        case allowARQuests = "ALLOW_AR_QUESTS"
+        case stopAllBootstrapping = "STOP_ALL_BOOTSTRAPPING"
+        case accUseRwForPokes = "USE_RW_FOR_POKES"
+        case questRetryLimit = "QUEST_RETRY_LIMIT"
+        case spinDistance = "SPIN_DISTANCE"
     }
 
 }

--- a/Sources/RealDeviceMapLib/Misc/HTTPRequest.swift
+++ b/Sources/RealDeviceMapLib/Misc/HTTPRequest.swift
@@ -15,7 +15,11 @@ internal extension HTTPRequest {
         if forwardedForHeader.isEmpty || !WebHookRequestHandler.hostWhitelistUsesProxy {
             hostString = self.remoteAddress.host
         } else {
-            hostString = forwardedForHeader
+            if forwardedForHeader.contains(",") {
+                hostString = forwardedForHeader.components(separatedBy: ",").first!.trimmingCharacters(in: .whitespaces)
+            } else {
+                hostString = forwardedForHeader
+            }
         }
         let hexParts = hostString.components(separatedBy: ":")
         if hexParts.count == 8 {

--- a/Sources/RealDeviceMapLib/Misc/ImageManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/ImageManager.swift
@@ -37,6 +37,7 @@ class ImageManager {
 
     private init() {
         updaterThread = Threading.getQueue(name: "ImageJsonUpdater", type: .serial)
+        Log.info(message: "[ImageManager] Image generation enabled: \(ImageManager.imageGenerationEnabled)")
         if !ImageManager.imageGenerationEnabled {
             return
         }

--- a/Sources/RealDeviceMapLib/Misc/ImageManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/ImageManager.swift
@@ -200,7 +200,7 @@ class ImageManager {
                 "\(reward.style)/reward/stardust/\(reward.uicon).png")
         } else if reward.type == POGOProtos.QuestRewardProto.TypeEnum.unset {
             baseFile = File("\(Dir.projectroot)/resources/webroot/static/img/" +
-                "\(reward.style)/reward/\(reward.uicon).png")
+                "\(reward.style)/reward/unset/\(reward.uicon).png")
         } else {
             baseFile = File("\(Dir.projectroot)/resources/webroot/static/img/" +
                 "\(reward.style)/reward/\(reward.type)/\(reward.uicon).png")

--- a/Sources/RealDeviceMapLib/Misc/MemoryCache.swift
+++ b/Sources/RealDeviceMapLib/Misc/MemoryCache.swift
@@ -15,8 +15,10 @@ public class MemoryCache<T> {
     private var store = [String: T]()
     private let hitsLock = Threading.Lock()
     private var hits = [String: Date]()
+    private var extendTtlOnHit: Bool
 
-    public init(interval: Double, keepTime: Double) {
+    public init(interval: Double, keepTime: Double, extendTtlOnHit: Bool = true) {
+        self.extendTtlOnHit = extendTtlOnHit
         let clearingQueue = Threading.getQueue(name: "MemoryCache-\(UUID().uuidString)-clearer", type: .serial)
         clearingQueue.dispatch {
             while true {
@@ -42,7 +44,7 @@ public class MemoryCache<T> {
         lock.readLock()
         let value = store[id]
         lock.unlock()
-        if value != nil {
+        if extendTtlOnHit && value != nil {
             hitsLock.lock()
             hits[id] = Date()
             hitsLock.unlock()

--- a/Sources/RealDeviceMapLib/Misc/PokemonFortProto.swift
+++ b/Sources/RealDeviceMapLib/Misc/PokemonFortProto.swift
@@ -1,0 +1,31 @@
+//
+// Created by fabio on 17.08.22.
+//
+
+import Foundation
+import POGOProtos
+
+extension PokemonFortProto {
+
+    func calculatePowerUpLevel(now: UInt32) -> (level: UInt16, timestamp: UInt32?) {
+        let powerUpLevelExpirationMs = UInt32(powerUpLevelExpirationMs / 1000)
+        let powerUpPoints = powerUpProgressPoints
+        var powerUpLevel: UInt16 = 0
+        var powerUpEndTimestamp: UInt32?
+        if powerUpPoints < 50 {
+            powerUpLevel = 0
+        } else if powerUpPoints < 100 && powerUpLevelExpirationMs > now {
+            powerUpLevel = 1
+            powerUpEndTimestamp = powerUpLevelExpirationMs
+        } else if powerUpPoints < 150 && powerUpLevelExpirationMs > now {
+            powerUpLevel = 2
+            powerUpEndTimestamp = powerUpLevelExpirationMs
+        } else if powerUpLevelExpirationMs > now {
+            powerUpLevel = 3
+            powerUpEndTimestamp = powerUpLevelExpirationMs
+        } else {
+            powerUpLevel = 0
+        }
+        return (powerUpLevel, powerUpEndTimestamp)
+    }
+}

--- a/Sources/RealDeviceMapLib/Modell/Account.swift
+++ b/Sources/RealDeviceMapLib/Modell/Account.swift
@@ -121,7 +121,8 @@ public class Account: WebHookEvent {
                 self.failedTimestamp = now
             } else {
                 if self.firstWarningTimestamp == nil {
-                    self.firstWarningTimestamp = warnExpireTimestamp - Account.warnedPeriod
+                    self.firstWarningTimestamp = warnExpireTimestamp > 0 ?
+                        warnExpireTimestamp - Account.warnedPeriod : now - Account.warnedPeriod
                 }
                 self.failedTimestamp = now - Account.warnedPeriod
             }

--- a/Sources/RealDeviceMapLib/Modell/Cell.swift
+++ b/Sources/RealDeviceMapLib/Modell/Cell.swift
@@ -90,7 +90,7 @@ class Cell: JSONConvertibleObject {
         mysqlStmt.bindParam(updated)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[CELL] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[CELL] Failed to execute query in save(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
         Cell.cache?.set(id: id.toString(), value: self)
@@ -124,7 +124,7 @@ class Cell: JSONConvertibleObject {
         mysqlStmt.bindParam(updated)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[CELL] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[CELL] Failed to execute query in getAll(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
         let results = mysqlStmt.results()
@@ -187,7 +187,7 @@ class Cell: JSONConvertibleObject {
         }
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[CELL] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[CELL] Failed to execute query in getInIDs(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
         let results = mysqlStmt.results()

--- a/Sources/RealDeviceMapLib/Modell/Cell.swift
+++ b/Sources/RealDeviceMapLib/Modell/Cell.swift
@@ -64,7 +64,7 @@ class Cell: JSONConvertibleObject {
             return
         }
 
-        var sql = """
+        let sql = """
         INSERT INTO `s2cell` (id, level, center_lat, center_lon, updated)
         VALUES (?, ?, ?, ?, UNIX_TIMESTAMP())
         ON DUPLICATE KEY UPDATE

--- a/Sources/RealDeviceMapLib/Modell/Cell.swift
+++ b/Sources/RealDeviceMapLib/Modell/Cell.swift
@@ -20,8 +20,10 @@ class Cell: JSONConvertibleObject {
     var centerLon: Double
     var updated: UInt32?
 
-    public static var cache: MemoryCache<UInt32> =
-        MemoryCache(interval: 900, keepTime: 3600)
+    var stopCount: Int = 0
+    var gymCount: Int = 0
+
+    public static var cache: MemoryCache<Cell>?
 
     override func getJSONValues() -> [String: Any] {
 
@@ -57,16 +59,21 @@ class Cell: JSONConvertibleObject {
             Log.error(message: "[CELL] Failed to connect to database.")
             throw DBController.DBError()
         }
-        let updated = Cell.cache.get(id: id.toString()) ?? 0
+        let oldCell = Cell.cache?.get(id: id.toString())
         let now = UInt32(Date().timeIntervalSince1970)
-        if updated > now - 900 {
+        if oldCell != nil && oldCell!.updated ?? 0 > now - 900 {
             // save only every 15 minutes
             return
         }
 
+        self.updated = now
+        // stop and gym count is only stored in cache
+        self.stopCount = oldCell?.stopCount ?? 0
+        self.gymCount = oldCell?.gymCount ?? 0
+
         let sql = """
         INSERT INTO `s2cell` (id, level, center_lat, center_lon, updated)
-        VALUES (?, ?, ?, ?, UNIX_TIMESTAMP())
+        VALUES (?, ?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE
         level=VALUES(level),
         center_lat=VALUES(center_lat),
@@ -80,12 +87,13 @@ class Cell: JSONConvertibleObject {
         mysqlStmt.bindParam(level)
         mysqlStmt.bindParam(centerLat)
         mysqlStmt.bindParam(centerLon)
+        mysqlStmt.bindParam(updated)
 
         guard mysqlStmt.execute() else {
             Log.error(message: "[CELL] Failed to execute query. (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
-        Cell.cache.set(id: id.toString(), value: now)
+        Cell.cache?.set(id: id.toString(), value: self)
     }
 
     public static func getAll(mysql: MySQL?=nil, minLat: Double, maxLat: Double,
@@ -198,5 +206,4 @@ class Cell: JSONConvertibleObject {
         return cells
 
     }
-
 }

--- a/Sources/RealDeviceMapLib/Modell/DeviceGroup.swift
+++ b/Sources/RealDeviceMapLib/Modell/DeviceGroup.swift
@@ -41,7 +41,7 @@ class DeviceGroup: Hashable {
         mysqlStmt.bindParam(name)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[DEVICEGROUP] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[DEVICEGROUP] Failed to execute query in create(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -65,7 +65,7 @@ class DeviceGroup: Hashable {
         }
 
         guard mysqlStmt.execute() else {
-           Log.error(message: "[DEVICEGROUP] Failed to execute query. (\(mysqlStmt.errorMessage())")
+           Log.error(message: "[DEVICEGROUP] Failed to execute query in createLinkings(). (\(mysqlStmt.errorMessage())")
            throw DBController.DBError()
         }
     }
@@ -87,7 +87,7 @@ class DeviceGroup: Hashable {
         mysqlStmt.bindParam(name)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[DEVICEGROUP] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[DEVICEGROUP] Failed to execute query in delete(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -112,7 +112,7 @@ class DeviceGroup: Hashable {
         mysqlStmt.bindParam(oldName)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[DEVICEGROUP] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[DEVICEGROUP] Failed to execute query in update(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -130,7 +130,7 @@ class DeviceGroup: Hashable {
         mysqlStmt.bindParam(name)
 
         guard mysqlStmt.execute() else {
-           Log.error(message: "[DEVICEGROUP] Failed to execute query. (\(mysqlStmt.errorMessage())")
+           Log.error(message: "[DEVICEGROUP] Failed to execute query in deleteLinkings(). (\(mysqlStmt.errorMessage())")
            throw DBController.DBError()
         }
     }
@@ -153,7 +153,7 @@ class DeviceGroup: Hashable {
         _ = mysqlStmt.prepare(statement: sql)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[DEVICEGROUP] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[DEVICEGROUP] Failed to execute query in getAll(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
         let results = mysqlStmt.results()
@@ -188,7 +188,7 @@ class DeviceGroup: Hashable {
         mysqlStmt.bindParam(name)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[DEVICEGROUP] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[DEVICEGROUP] Failed to execute query in getByName(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
         let results = mysqlStmt.results()

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -405,16 +405,30 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
             case .withDailySpinBonus: break
             case .withUniquePokemon: break
             case .withBuddyInterestingPoi: break
-            case .withPokemonLevel: break
+            case .withPokemonLevel:
+                let info = conditionData.withPokemonLevel
+                infoData["must_be_max_level"] = info.maxLevel
             case .withSingleDay: break
             case .withUniquePokemonTeam: break
-            case .withMaxCp: break
+            case .withMaxCp:
+                let info = conditionData.withMaxCp
+                infoData["with_max_cp"] = info.maxCp
             case .withLuckyPokemon: break
             case .withLegendaryPokemon: break
-            case .withGblRank: break
+            case .withGblRank:
+                let info = conditionData.withGblRank
+                infoData["with_league_rank"] = info.rank
             case .withCatchesInARow: break
-            case .withEncounterType: break
-            case .withCombatType: break
+            case .withEncounterType:
+                let info = conditionData.withEncounterType
+                infoData["encounter_type"] = info.encounterType.map({ (type) -> Int in
+                    return type.rawValue
+                })
+            case .withCombatType:
+                let info = conditionData.withCombatType
+                infoData["combat_type"] = info.combatType.map({ (type) -> Int in
+                    return type.rawValue
+                })
             case .withGeotargetedPoi: break
             case .withFriendLevel: break
             case .withSticker: break
@@ -484,7 +498,9 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
                 infoData["pokemon_id"] = info.pokemonID.rawValue
             case .avatarClothing: break
             case .quest: break
-            case .levelCap: break
+            case .levelCap:
+                let info = rewardData.levelCap
+                infoData["level_cap"] = info
             case .incident: break
             case .playerAttribute: break
             case .unset: break

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -1088,7 +1088,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
 
         let sql = """
             UPDATE pokestop
-            SET updated = UNIX_TIMESTAMP(), quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
+            SET quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
                 quest_conditions = NULL, quest_rewards = NULL, quest_template = NULL, quest_title = NULL,
                 alternative_quest_type = NULL, alternative_quest_timestamp = NULL, alternative_quest_target = NULL,
                 alternative_quest_conditions = NULL, alternative_quest_rewards = NULL,
@@ -1141,7 +1141,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
         let coords = Pokestop.flattenCoords(area: areaString)
         let sql = """
             UPDATE pokestop
-            SET updated = UNIX_TIMESTAMP(), quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
+            SET quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
                 quest_conditions = NULL, quest_rewards = NULL, quest_template = NULL, quest_title = NULL,
                 alternative_quest_type = NULL, alternative_quest_timestamp = NULL, alternative_quest_target = NULL,
                 alternative_quest_conditions = NULL, alternative_quest_rewards = NULL,
@@ -1182,7 +1182,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
         let coords = Pokestop.flattenCoords(area: areaString)
         let sql = """
             UPDATE pokestop
-            SET updated = UNIX_TIMESTAMP(), quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
+            SET quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
                 quest_conditions = NULL, quest_rewards = NULL, quest_template = NULL, quest_title = NULL,
                 alternative_quest_type = NULL, alternative_quest_timestamp = NULL, alternative_quest_target = NULL,
                 alternative_quest_conditions = NULL, alternative_quest_rewards = NULL,

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -12,7 +12,7 @@ import PerfectLib
 import PerfectMySQL
 import POGOProtos
 
-public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
+public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
 
     public static var lureTime: UInt32 = 1800
 
@@ -134,7 +134,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
     var lastModifiedTimestamp: UInt32?
     var name: String?
     var url: String?
-    var sponsorId: UInt16?
+    var sponsorId: UInt16? // unused
     var partnerId: String?
     var updated: UInt32?
     var arScanEligible: Bool?
@@ -159,11 +159,14 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
     var lureId: Int16?
     var incidents: [Incident]
 
-    var hasChanges = false
-    var hasQuestChanges = false
-    var hasAlternativeQuestChanges = false
-
     public static var cache: MemoryCache<Pokestop>?
+
+    override init() {
+        self.id = ""
+        self.lat = 0.0
+        self.lon = 0.0
+        self.incidents = []
+    }
 
     init(id: String, lat: Double, lon: Double, name: String?, url: String?, enabled: Bool?,
          lureExpireTimestamp: UInt32?, lastModifiedTimestamp: UInt32?, updated: UInt32?, questType: UInt32?,
@@ -208,46 +211,35 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         self.incidents = incidents
     }
 
-    init(fortData: PokemonFortProto, cellId: UInt64) {
-
+    func updateFromFort(fortData: PokemonFortProto, cellId: UInt64) {
+        let now = UInt32(Date().timeIntervalSince1970)
         self.id = fortData.fortID
         self.lat = fortData.latitude
         self.lon = fortData.longitude
-        self.partnerId = fortData.partnerID != "" ? fortData.partnerID : nil
-        if fortData.sponsor != .unset {
-            self.sponsorId = UInt16(fortData.sponsor.rawValue)
-        }
         self.enabled = fortData.enabled
         self.arScanEligible = fortData.isArScanEligible
-        let now = UInt32(Date().timeIntervalSince1970)
-        let powerUpLevelExpirationMs = UInt32(fortData.powerUpLevelExpirationMs / 1000)
-        self.powerUpPoints = UInt32(fortData.powerUpProgressPoints)
-        if fortData.powerUpProgressPoints < 50 {
-            self.powerUpLevel = 0
-        } else if fortData.powerUpProgressPoints < 100 && powerUpLevelExpirationMs > now {
-            self.powerUpLevel = 1
-            self.powerUpEndTimestamp = powerUpLevelExpirationMs
-        } else if fortData.powerUpProgressPoints < 150 && powerUpLevelExpirationMs > now {
-            self.powerUpLevel = 2
-            self.powerUpEndTimestamp = powerUpLevelExpirationMs
-        } else if powerUpLevelExpirationMs > now {
-            self.powerUpLevel = 3
-            self.powerUpEndTimestamp = powerUpLevelExpirationMs
-        } else {
-            self.powerUpLevel = 0
-        }
+        self.partnerId = fortData.partnerID.isEmpty ? nil : fortData.partnerID
+
+        (self.powerUpLevel, self.powerUpEndTimestamp) = fortData.calculatePowerUpLevel(now: now)
 
         let lastModifiedTimestamp = UInt32(fortData.lastModifiedMs / 1000)
-        if fortData.activeFortModifier.contains(.troyDisk) ||
-            fortData.activeFortModifier.contains(.troyDiskGlacial) ||
-            fortData.activeFortModifier.contains(.troyDiskMossy) ||
-            fortData.activeFortModifier.contains(.troyDiskMagnetic) ||
-            fortData.activeFortModifier.contains(.troyDiskRainy) {
-            self.lureExpireTimestamp = lastModifiedTimestamp + Pokestop.lureTime
-            self.lureId = Int16(fortData.activeFortModifier[0].rawValue)
-        }
         self.lastModifiedTimestamp = lastModifiedTimestamp
-        if fortData.imageURL != "" {
+        if fortData.activeFortModifier.count > 0 {
+            let lureId = Int16(fortData.activeFortModifier[0].rawValue)
+            if lureId >= 501 && lureId <= 505 {
+                let lureEnd = lastModifiedTimestamp + Pokestop.lureTime
+                if self.lureId != lureId {
+                    self.lureExpireTimestamp = lureEnd
+                    self.lureId = lureId
+                } else {
+                    if now > lureEnd + 30 { // wait some time after lure end before a restart in case of timing issue
+                        // If a lure needs to be restarted
+                        self.lureExpireTimestamp = lureEnd
+                    }
+                }
+            }
+        }
+        if !fortData.imageURL.isEmpty {
             self.url = fortData.imageURL
         }
         self.cellId = cellId
@@ -259,38 +251,37 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
             Incident(now: now, pokestopId: fortData.fortID, pokestopDisplay: pokestopDisplay) })
     }
 
-    public func addDetails(fortData: FortDetailsOutProto) {
-
+    func updateFromFortDetails(fortData: FortDetailsOutProto) {
         self.id = fortData.id
         self.lat = fortData.latitude
         self.lon = fortData.longitude
         if !fortData.imageURL.isEmpty {
-            let url = fortData.imageURL[0]
-            if self.url != url {
-                hasChanges = true
-            }
-            self.url = url
+            self.url = fortData.imageURL[0]
         }
-        let name = fortData.name
-        if self.name != name {
-            hasChanges = true
-        }
-        self.name = name
+        self.name = fortData.name
+//        if !fortData.description_p.isEmpty {
+//            self.description = fortData.description_p
+//        } else {
+//            self.description = nil
+//        }
 
+//        if fortData.promoDescription.count != 0 {
+//            let promoDescription = fortData.promoDescription.jsonEncodeForceTry()
+//            Log.debug(message: "[POKESTOP] Pokestop \(id) found with promo: \(promoDescription ?? "")")
+//        }
     }
 
-    public func addQuest(title: String, questData: QuestProto, hasARQuest: Bool) {
-
-        let questType = questData.questType.rawValue.toUInt32()
-        let questTarget = UInt16(questData.goal.target)
-        let questTemplate = questData.templateID.lowercased()
-        let questTitle = title.lowercased()
-        self.hasChanges = true
+    public func updatePokestopFromQuestProto(questData: ClientQuestProto, hasARQuest: Bool) {
+        let quest = questData.quest
+        let questType = quest.questType.rawValue.toUInt32()
+        let questTarget = UInt16(quest.goal.target)
+        let questTemplate = quest.templateID.lowercased()
+        let questTitle = questData.questDisplay.title.lowercased()
 
         var conditions = [[String: Any]]()
         var rewards = [[String: Any]]()
 
-        for conditionData in questData.goal.condition {
+        for conditionData in quest.goal.condition {
             var condition = [String: Any]()
             var infoData = [String: Any]()
             condition["type"] = conditionData.type.rawValue
@@ -435,7 +426,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
             conditions.append(condition)
         }
 
-        for rewardData in questData.questRewards {
+        for rewardData in quest.questRewards {
             var reward = [String: Any]()
             var infoData = [String: Any]()
             reward["type"] = rewardData.type.rawValue
@@ -509,7 +500,6 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
              self.alternativeQuestConditions = questConditions
              self.alternativeQuestRewards = questRewards
              self.alternativeQuestTimestamp = questTimestamp
-             self.hasAlternativeQuestChanges = true
          } else {
              self.questType = questType
              self.questTarget = questTarget
@@ -518,12 +508,11 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
              self.questConditions = questConditions
              self.questRewards = questRewards
              self.questTimestamp = questTimestamp
-             self.hasQuestChanges = true
          }
 
     }
 
-    public func save(mysql: MySQL?=nil, updateQuest: Bool=false) throws {
+    public func save(mysql: MySQL?=nil) throws {
 
         guard let mysql = mysql ?? DBController.global.mysql else {
             Log.error(message: "[POKESTOP] Failed to connect to database.")
@@ -536,9 +525,19 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         } catch {
             oldPokestop = nil
         }
-        let mysqlStmt = MySQLStmt(mysql)
 
         let now = UInt32(Date().timeIntervalSince1970)
+
+        if oldPokestop != nil && !Pokestop.hasChanges(old: oldPokestop!, new: self) {
+            if self.updated! > now - 600 {
+                // if a pokestop is unchanged but we did see it again after 10 minutes, then save again
+                return
+            }
+        }
+
+        let mysqlStmt = MySQLStmt(mysql)
+
+        self.updated = now
 
         if oldPokestop == nil {
             let sql = """
@@ -551,110 +550,48 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
                     power_up_points, power_up_level, power_up_end_timestamp, updated, first_seen_timestamp)
                 VALUES (
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    UNIX_TIMESTAMP(), UNIX_TIMESTAMP())
+                    ?, UNIX_TIMESTAMP())
             """
-            self.updated = now
             _ = mysqlStmt.prepare(statement: sql)
             mysqlStmt.bindParam(id)
         } else {
-            if oldPokestop!.cellId != nil && self.cellId == nil {
-                self.cellId = oldPokestop!.cellId
-            }
-
-            if oldPokestop!.name != nil && self.name == nil {
-                self.name = oldPokestop!.name
-            }
-            if oldPokestop!.url != nil && self.url == nil {
-                self.url = oldPokestop!.url
-            }
-            if updateQuest && oldPokestop!.questType != nil && self.questType == nil {
-                self.questType = oldPokestop!.questType
-                self.questTarget = oldPokestop!.questTarget
-                self.questConditions = oldPokestop!.questConditions
-                self.questRewards = oldPokestop!.questRewards
-                self.questTimestamp = oldPokestop!.questTimestamp
-                self.questTemplate = oldPokestop!.questTemplate
-                self.questTitle = oldPokestop!.questTitle
-            }
-            if updateQuest && oldPokestop!.alternativeQuestType != nil && self.alternativeQuestType == nil {
-                self.alternativeQuestType = oldPokestop!.alternativeQuestType
-                self.alternativeQuestTarget = oldPokestop!.alternativeQuestTarget
-                self.alternativeQuestConditions = oldPokestop!.alternativeQuestConditions
-                self.alternativeQuestRewards = oldPokestop!.alternativeQuestRewards
-                self.alternativeQuestTimestamp = oldPokestop!.alternativeQuestTimestamp
-                self.alternativeQuestTemplate = oldPokestop!.alternativeQuestTemplate
-                self.alternativeQuestTitle = oldPokestop!.alternativeQuestTitle
-            }
-            if oldPokestop!.lureId != nil && self.lureId == nil {
-                self.lureId = oldPokestop!.lureId
-            }
-
-            guard Pokestop.shouldUpdate(old: oldPokestop!, new: self) else {
-                return
-            }
-
-            if oldPokestop!.lureExpireTimestamp ?? 0 < self.lureExpireTimestamp ?? 0 {
-                WebHookController.global.addLureEvent(pokestop: self)
-            }
-            if updateQuest && questTimestamp ?? 0 > oldPokestop!.questTimestamp ?? 0 {
-                WebHookController.global.addQuestEvent(pokestop: self)
-            }
-            if updateQuest && alternativeQuestTimestamp ?? 0 > oldPokestop!.alternativeQuestTimestamp ?? 0 {
-                WebHookController.global.addAlternativeQuestEvent(pokestop: self)
-            }
-
-            var questSQL = ""
-            if updateQuest && questTimestamp ?? 0 > 0 {
-                questSQL += "quest_type = ?, quest_timestamp = ?, quest_target = ?, quest_conditions = ?, " +
-                            "quest_rewards = ?, quest_template = ?, quest_title = ?,"
-            }
-            if updateQuest && alternativeQuestTimestamp ?? 0 > 0 {
-                questSQL += "alternative_quest_type = ?, alternative_quest_timestamp = ?, " +
-                            "alternative_quest_target = ?, alternative_quest_conditions = ?, " +
-                            "alternative_quest_rewards = ?, alternative_quest_template = ?," +
-                            "alternative_quest_title = ?,"
-            }
-
-            let nameSQL = name != nil ? "name = ?, " : ""
             let sql = """
                 UPDATE pokestop
-                SET lat = ?, lon = ?, \(nameSQL) url = ?, enabled = ?, lure_expire_timestamp = ?,
-                    last_modified_timestamp = ?, updated = UNIX_TIMESTAMP(), \(questSQL) cell_id = ?,
-                    lure_id = ?, deleted = false, sponsor_id = ?, partner_id = ?, ar_scan_eligible = ?,
-                    power_up_points = ?, power_up_level = ?, power_up_end_timestamp = ?
+                SET lat = ?, lon = ?, name = ?, url = ?, enabled = ?, lure_expire_timestamp = ?,
+                    last_modified_timestamp = ?, quest_type = ?, quest_timestamp = ?,
+                    quest_target = ?, quest_conditions = ?, quest_rewards = ?, quest_template = ?, quest_title = ?,
+                    alternative_quest_type = ?, alternative_quest_timestamp = ?, alternative_quest_target = ?,
+                    alternative_quest_conditions = ?, alternative_quest_rewards = ?, alternative_quest_template = ?,
+                    alternative_quest_title = ?, cell_id = ?, lure_id = ?, deleted = false, sponsor_id = ?,
+                    partner_id = ?, ar_scan_eligible = ?, power_up_points = ?, power_up_level = ?,
+                    power_up_end_timestamp = ?, updated = ?
                 WHERE id = ?
             """
-            self.updated = now
+
             _ = mysqlStmt.prepare(statement: sql)
         }
 
         mysqlStmt.bindParam(lat)
         mysqlStmt.bindParam(lon)
-        if oldPokestop == nil || name != nil {
-            mysqlStmt.bindParam(name)
-        }
+        mysqlStmt.bindParam(name)
         mysqlStmt.bindParam(url)
         mysqlStmt.bindParam(enabled)
         mysqlStmt.bindParam(lureExpireTimestamp)
         mysqlStmt.bindParam(lastModifiedTimestamp)
-        if (updateQuest && questTimestamp ?? 0 > 0) || oldPokestop == nil {
-            mysqlStmt.bindParam(questType)
-            mysqlStmt.bindParam(questTimestamp)
-            mysqlStmt.bindParam(questTarget)
-            mysqlStmt.bindParam(questConditions.jsonEncodeForceTry())
-            mysqlStmt.bindParam(questRewards.jsonEncodeForceTry())
-            mysqlStmt.bindParam(questTemplate)
-            mysqlStmt.bindParam(questTitle)
-        }
-        if (updateQuest && alternativeQuestTimestamp ?? 0 > 0) || oldPokestop == nil {
-            mysqlStmt.bindParam(alternativeQuestType)
-            mysqlStmt.bindParam(alternativeQuestTimestamp)
-            mysqlStmt.bindParam(alternativeQuestTarget)
-            mysqlStmt.bindParam(alternativeQuestConditions.jsonEncodeForceTry())
-            mysqlStmt.bindParam(alternativeQuestRewards.jsonEncodeForceTry())
-            mysqlStmt.bindParam(alternativeQuestTemplate)
-            mysqlStmt.bindParam(alternativeQuestTitle)
-        }
+        mysqlStmt.bindParam(questType)
+        mysqlStmt.bindParam(questTimestamp)
+        mysqlStmt.bindParam(questTarget)
+        mysqlStmt.bindParam(questConditions.jsonEncodeForceTry())
+        mysqlStmt.bindParam(questRewards.jsonEncodeForceTry())
+        mysqlStmt.bindParam(questTemplate)
+        mysqlStmt.bindParam(questTitle)
+        mysqlStmt.bindParam(alternativeQuestType)
+        mysqlStmt.bindParam(alternativeQuestTimestamp)
+        mysqlStmt.bindParam(alternativeQuestTarget)
+        mysqlStmt.bindParam(alternativeQuestConditions.jsonEncodeForceTry())
+        mysqlStmt.bindParam(alternativeQuestRewards.jsonEncodeForceTry())
+        mysqlStmt.bindParam(alternativeQuestTemplate)
+        mysqlStmt.bindParam(alternativeQuestTitle)
         mysqlStmt.bindParam(cellId)
         mysqlStmt.bindParam(lureId ?? 0)
         mysqlStmt.bindParam(sponsorId)
@@ -663,6 +600,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         mysqlStmt.bindParam(powerUpPoints)
         mysqlStmt.bindParam(powerUpLevel)
         mysqlStmt.bindParam(powerUpEndTimestamp)
+        mysqlStmt.bindParam(updated)
 
         if oldPokestop != nil {
             mysqlStmt.bindParam(id)
@@ -679,32 +617,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
 
         Pokestop.cache?.set(id: self.id, value: self)
 
-        if oldPokestop == nil {
-            WebHookController.global.addPokestopEvent(pokestop: self)
-            if lureExpireTimestamp ?? 0 > 0 {
-                WebHookController.global.addLureEvent(pokestop: self)
-            }
-            if questTimestamp ?? 0 > 0 {
-                WebHookController.global.addQuestEvent(pokestop: self)
-            }
-            if alternativeQuestTimestamp ?? 0 > 0 {
-                WebHookController.global.addAlternativeQuestEvent(pokestop: self)
-            }
-        } else {
-            if oldPokestop!.lureExpireTimestamp ?? 0 < self.lureExpireTimestamp ?? 0 {
-                WebHookController.global.addLureEvent(pokestop: self)
-            }
-            if updateQuest && (hasQuestChanges || questTimestamp ?? 0 > oldPokestop!.questTimestamp ?? 0) {
-                hasQuestChanges = false
-                WebHookController.global.addQuestEvent(pokestop: self)
-            }
-            if updateQuest && (hasAlternativeQuestChanges ||
-                alternativeQuestTimestamp ?? 0 > oldPokestop!.alternativeQuestTimestamp ?? 0
-            ) {
-                hasAlternativeQuestChanges = false
-                WebHookController.global.addAlternativeQuestEvent(pokestop: self)
-            }
-        }
+        Pokestop.createPokestopWebhooks(old: oldPokestop, new: self)
     }
 
     //  swiftlint:disable:next function_parameter_count
@@ -1083,10 +996,16 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         return count
     }
 
-    public static func getWithId(mysql: MySQL?=nil, id: String, withDeleted: Bool=false) throws -> Pokestop? {
+    public static func getWithId(mysql: MySQL?=nil, id: String, copy: Bool = false, withDeleted: Bool=false
+    ) throws -> Pokestop? {
 
         if let cached = cache?.get(id: id) {
-            return cached
+            // it's a reference type instance, without copying it we would modify the instance within cache
+            if copy {
+                return (cached.copy() as! Pokestop)
+            } else {
+                return cached
+            }
         }
 
         guard let mysql = mysql ?? DBController.global.mysql else {
@@ -1134,132 +1053,6 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         let pokestop = extractResults(results: results).first!
         cache?.set(id: pokestop.id, value: pokestop)
         return pokestop
-    }
-
-    private static func extractResults(results: MySQLStmt.Results, showLures: Bool = true, showInvasions: Bool = true,
-                                       showQuests: Bool = true) -> [Pokestop] {
-        var pokestops = [String: Pokestop]()
-        while let result = results.next() {
-            let id = result[0] as! String
-            let lat = result[1] as! Double
-            let lon = result[2] as! Double
-            let name = result[3] as? String
-            let url = result[4] as? String
-            let enabledInt = result[5] as? UInt8
-            let enabled = enabledInt?.toBool()
-            let lureExpireTimestamp: UInt32?
-            if showLures {
-                lureExpireTimestamp = result[6] as? UInt32
-            } else {
-                lureExpireTimestamp = nil
-            }
-            let lastModifiedTimestamp = result[7] as? UInt32
-            let updated = result[8] as! UInt32
-
-            let questType: UInt32?
-            let questTimestamp: UInt32?
-            let questTarget: UInt16?
-            let questConditions: [[String: Any]]?
-            let questRewards: [[String: Any]]?
-            let questTemplate: String?
-            let questTitle: String?
-            let alternativeQuestType: UInt32?
-            let alternativeQuestTimestamp: UInt32?
-            let alternativeQuestTarget: UInt16?
-            let alternativeQuestConditions: [[String: Any]]?
-            let alternativeQuestRewards: [[String: Any]]?
-            let alternativeQuestTemplate: String?
-            let alternativeQuestTitle: String?
-
-            if showQuests {
-                questType = result[9] as? UInt32
-                questTimestamp = result[10] as? UInt32
-                questTarget = result[11] as? UInt16
-                questConditions = (result[12] as? String)?.jsonDecodeForceTry() as? [[String: Any]]
-                questRewards = (result[13] as? String)?.jsonDecodeForceTry() as? [[String: Any]]
-                questTemplate = result[14] as? String
-                questTitle = result[15] as? String
-                alternativeQuestType = result[16] as? UInt32
-                alternativeQuestTimestamp = result[17] as? UInt32
-                alternativeQuestTarget = result[18] as? UInt16
-                alternativeQuestConditions = (result[19] as? String)?.jsonDecodeForceTry() as? [[String: Any]]
-                alternativeQuestRewards = (result[20] as? String)?.jsonDecodeForceTry() as? [[String: Any]]
-                alternativeQuestTemplate = result[21] as? String
-                alternativeQuestTitle = result[22] as? String
-            } else {
-                questType = nil
-                questTimestamp = nil
-                questTarget = nil
-                questConditions = nil
-                questRewards = nil
-                questTemplate = nil
-                questTitle = nil
-                alternativeQuestType = nil
-                alternativeQuestTimestamp = nil
-                alternativeQuestTarget = nil
-                alternativeQuestConditions = nil
-                alternativeQuestRewards = nil
-                alternativeQuestTemplate = nil
-                alternativeQuestTitle = nil
-            }
-            let cellId = result[23] as? UInt64
-            let lureId: Int16?
-            if showLures {
-                lureId = result[24] as? Int16
-            } else {
-                lureId = nil
-            }
-            let sponsorId = result[25] as? UInt16
-            let partnerId = result[26] as? String
-            let arScanEligible = (result[27] as? UInt8)?.toBool()
-            let powerUpPoints = result[28] as? UInt32
-            let powerUpLevel = result[29] as? UInt16
-            let powerUpEndTimestamp = result[30] as? UInt32
-
-            let incident: Incident?
-            if showInvasions {
-                let incidentId = result[31] as? String
-                if incidentId != nil {
-                    let pokestopId = result[32] as! String
-                    let start = result[33] as! UInt32
-                    let expiration = result[34] as! UInt32
-                    let displayType = result[35] as! UInt16
-                    let style = result[36] as! UInt16
-                    let character = result[37] as! UInt16
-                    let incidentUpdated = result[38] as! UInt32
-                    incident = Incident(id: incidentId!, pokestopId: pokestopId, start: start, expiration: expiration,
-                        displayType: displayType, style: style, character: character, updated: incidentUpdated)
-                } else {
-                    incident = nil
-                }
-            } else {
-                incident = nil
-            }
-            // duplicate rows because of JOIN with incident table possible
-            if pokestops[id] != nil {
-                if incident != nil {
-                    pokestops[id]!.incidents.append(incident!)
-                }
-            } else {
-                let incidents = incident != nil ? [incident!] : [Incident]()
-                pokestops.merge([id: Pokestop(
-                    id: id, lat: lat, lon: lon, name: name, url: url, enabled: enabled,
-                    lureExpireTimestamp: lureExpireTimestamp, lastModifiedTimestamp: lastModifiedTimestamp,
-                    updated: updated, questType: questType, questTarget: questTarget, questTimestamp: questTimestamp,
-                    questConditions: questConditions, questRewards: questRewards, questTemplate: questTemplate,
-                    questTitle: questTitle, cellId: cellId, lureId: lureId, sponsorId: sponsorId, partnerId: partnerId,
-                    arScanEligible: arScanEligible, powerUpPoints: powerUpPoints, powerUpLevel: powerUpLevel,
-                    powerUpEndTimestamp: powerUpEndTimestamp,
-                    alternativeQuestType: alternativeQuestType, alternativeQuestTarget: alternativeQuestTarget,
-                    alternativeQuestTimestamp: alternativeQuestTimestamp,
-                    alternativeQuestConditions: alternativeQuestConditions,
-                    alternativeQuestRewards: alternativeQuestRewards,
-                    alternativeQuestTemplate: alternativeQuestTemplate,
-                    alternativeQuestTitle: alternativeQuestTitle, incidents: incidents
-                )]) { (current, _) in current }
-            }
-        }
-        return Array(pokestops.values)
     }
 
     public static func clearQuests(mysql: MySQL?=nil, ids: [String]?=nil) throws {
@@ -1409,27 +1202,6 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         }
     }
 
-    public static func flattenCoords(area: String) -> String {
-        var coords = ""
-        var firstCoord = ""
-        let areaRows = area.components(separatedBy: "\n")
-        for (index, areaRow) in areaRows.enumerated() {
-            let rowSplit = areaRow.components(separatedBy: ",")
-            if rowSplit.count == 2 {
-                let lat = rowSplit[0].trimmingCharacters(in: .whitespaces).toDouble()
-                let lon = rowSplit[1].trimmingCharacters(in: .whitespaces).toDouble()
-                if lat != nil && lon != nil {
-                    let coord = "\(lat!) \(lon!)"
-                    if index == 0 {
-                        firstCoord = coord
-                    }
-                    coords += "\(coord),"
-                }
-            }
-        }
-        return coords + firstCoord
-    }
-
     public static func clearOld(mysql: MySQL?=nil, ids: [String], cellId: UInt64) throws -> UInt {
 
         guard let mysql = mysql ?? DBController.global.mysql else {
@@ -1568,11 +1340,43 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
         return mysqlStmt.affectedRows()
     }
 
-    public static func shouldUpdate(old: Pokestop, new: Pokestop) -> Bool {
-        if old.hasChanges {
-            old.hasChanges = false
-            return true
+    public static func == (lhs: Pokestop, rhs: Pokestop) -> Bool {
+        return lhs.id == rhs.id
+    }
+
+    public func copy(with zone: NSZone? = nil) -> Any {
+        Pokestop(id: id, lat: lat, lon: lon, name: name, url: url, enabled: enabled,
+            lureExpireTimestamp: lureExpireTimestamp, lastModifiedTimestamp: lastModifiedTimestamp, updated: updated,
+            questType: questType, questTarget: questTarget, questTimestamp: questTimestamp,
+            questConditions: questConditions, questRewards: questRewards, questTemplate: questTemplate,
+            questTitle: questTitle, cellId: cellId, lureId: lureId, sponsorId: sponsorId, partnerId: partnerId,
+            arScanEligible: arScanEligible, powerUpPoints: powerUpPoints, powerUpLevel: powerUpLevel,
+            powerUpEndTimestamp: powerUpEndTimestamp, alternativeQuestType: alternativeQuestType,
+            alternativeQuestTarget: alternativeQuestTarget, alternativeQuestTimestamp: alternativeQuestTimestamp,
+            alternativeQuestConditions: alternativeQuestConditions, alternativeQuestRewards: alternativeQuestRewards,
+            alternativeQuestTemplate: alternativeQuestTemplate, alternativeQuestTitle: alternativeQuestTitle,
+            incidents: incidents)
+    }
+
+    // =================================================================================================================
+    //  HELPER METHODS
+    // =================================================================================================================
+
+    private static func createPokestopWebhooks(old: Pokestop?, new: Pokestop) {
+        if new.alternativeQuestType != nil && (old == nil || old!.alternativeQuestType != new.alternativeQuestType) {
+            WebHookController.global.addAlternativeQuestEvent(pokestop: new)
         }
+        if new.questType != nil && (old == nil || old!.questType != new.questType) {
+            WebHookController.global.addQuestEvent(pokestop: new)
+        }
+        if (old == nil && new.lureId ?? 0 != 0 || new.powerUpEndTimestamp ?? 0 != 0) ||
+               (old != nil && ((new.lureExpireTimestamp != old!.lureExpireTimestamp && new.lureId ?? 0 != 0) ||
+                   new.powerUpEndTimestamp != old?.powerUpEndTimestamp)) {
+            WebHookController.global.addPokestopEvent(pokestop: new)
+        }
+    }
+
+    private static func hasChanges(old: Pokestop, new: Pokestop) -> Bool {
         return
             new.lastModifiedTimestamp != old.lastModifiedTimestamp ||
             new.lureExpireTimestamp != old.lureExpireTimestamp ||
@@ -1581,6 +1385,7 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
             new.name != old.name ||
             new.url != old.url ||
             new.arScanEligible != old.arScanEligible ||
+            new.powerUpLevel != old.powerUpLevel ||
             new.powerUpPoints != old.powerUpPoints ||
             new.powerUpEndTimestamp != old.powerUpEndTimestamp ||
             new.questTemplate != old.questTemplate ||
@@ -1592,8 +1397,150 @@ public class Pokestop: JSONConvertibleObject, WebHookEvent, Hashable {
             fabs(new.lon - old.lon) >= 0.000001
     }
 
-    public static func == (lhs: Pokestop, rhs: Pokestop) -> Bool {
-        return lhs.id == rhs.id
+    private static func flattenCoords(area: String) -> String {
+        var coords = ""
+        var firstCoord = ""
+        let areaRows = area.components(separatedBy: "\n")
+        for (index, areaRow) in areaRows.enumerated() {
+            let rowSplit = areaRow.components(separatedBy: ",")
+            if rowSplit.count == 2 {
+                let lat = rowSplit[0].trimmingCharacters(in: .whitespaces).toDouble()
+                let lon = rowSplit[1].trimmingCharacters(in: .whitespaces).toDouble()
+                if lat != nil && lon != nil {
+                    let coord = "\(lat!) \(lon!)"
+                    if index == 0 {
+                        firstCoord = coord
+                    }
+                    coords += "\(coord),"
+                }
+            }
+        }
+        return coords + firstCoord
     }
 
+    private static func extractResults(results: MySQLStmt.Results, showLures: Bool = true, showInvasions: Bool = true,
+                                       showQuests: Bool = true) -> [Pokestop] {
+        var pokestops = [String: Pokestop]()
+        while let result = results.next() {
+            let id = result[0] as! String
+            let lat = result[1] as! Double
+            let lon = result[2] as! Double
+            let name = result[3] as? String
+            let url = result[4] as? String
+            let enabledInt = result[5] as? UInt8
+            let enabled = enabledInt?.toBool()
+            let lureExpireTimestamp: UInt32?
+            if showLures {
+                lureExpireTimestamp = result[6] as? UInt32
+            } else {
+                lureExpireTimestamp = nil
+            }
+            let lastModifiedTimestamp = result[7] as? UInt32
+            let updated = result[8] as! UInt32
+
+            let questType: UInt32?
+            let questTimestamp: UInt32?
+            let questTarget: UInt16?
+            let questConditions: [[String: Any]]?
+            let questRewards: [[String: Any]]?
+            let questTemplate: String?
+            let questTitle: String?
+            let alternativeQuestType: UInt32?
+            let alternativeQuestTimestamp: UInt32?
+            let alternativeQuestTarget: UInt16?
+            let alternativeQuestConditions: [[String: Any]]?
+            let alternativeQuestRewards: [[String: Any]]?
+            let alternativeQuestTemplate: String?
+            let alternativeQuestTitle: String?
+
+            if showQuests {
+                questType = result[9] as? UInt32
+                questTimestamp = result[10] as? UInt32
+                questTarget = result[11] as? UInt16
+                questConditions = (result[12] as? String)?.jsonDecodeForceTry() as? [[String: Any]]
+                questRewards = (result[13] as? String)?.jsonDecodeForceTry() as? [[String: Any]]
+                questTemplate = result[14] as? String
+                questTitle = result[15] as? String
+                alternativeQuestType = result[16] as? UInt32
+                alternativeQuestTimestamp = result[17] as? UInt32
+                alternativeQuestTarget = result[18] as? UInt16
+                alternativeQuestConditions = (result[19] as? String)?.jsonDecodeForceTry() as? [[String: Any]]
+                alternativeQuestRewards = (result[20] as? String)?.jsonDecodeForceTry() as? [[String: Any]]
+                alternativeQuestTemplate = result[21] as? String
+                alternativeQuestTitle = result[22] as? String
+            } else {
+                questType = nil
+                questTimestamp = nil
+                questTarget = nil
+                questConditions = nil
+                questRewards = nil
+                questTemplate = nil
+                questTitle = nil
+                alternativeQuestType = nil
+                alternativeQuestTimestamp = nil
+                alternativeQuestTarget = nil
+                alternativeQuestConditions = nil
+                alternativeQuestRewards = nil
+                alternativeQuestTemplate = nil
+                alternativeQuestTitle = nil
+            }
+            let cellId = result[23] as? UInt64
+            let lureId: Int16?
+            if showLures {
+                lureId = result[24] as? Int16
+            } else {
+                lureId = nil
+            }
+            let sponsorId = result[25] as? UInt16
+            let partnerId = result[26] as? String
+            let arScanEligible = (result[27] as? UInt8)?.toBool()
+            let powerUpPoints = result[28] as? UInt32
+            let powerUpLevel = result[29] as? UInt16
+            let powerUpEndTimestamp = result[30] as? UInt32
+
+            let incident: Incident?
+            if showInvasions {
+                let incidentId = result[31] as? String
+                if incidentId != nil {
+                    let pokestopId = result[32] as! String
+                    let start = result[33] as! UInt32
+                    let expiration = result[34] as! UInt32
+                    let displayType = result[35] as! UInt16
+                    let style = result[36] as! UInt16
+                    let character = result[37] as! UInt16
+                    let incidentUpdated = result[38] as! UInt32
+                    incident = Incident(id: incidentId!, pokestopId: pokestopId, start: start, expiration: expiration,
+                        displayType: displayType, style: style, character: character, updated: incidentUpdated)
+                } else {
+                    incident = nil
+                }
+            } else {
+                incident = nil
+            }
+            // duplicate rows because of JOIN with incident table possible
+            if pokestops[id] != nil {
+                if incident != nil {
+                    pokestops[id]!.incidents.append(incident!)
+                }
+            } else {
+                let incidents = incident != nil ? [incident!] : [Incident]()
+                pokestops.merge([id: Pokestop(
+                    id: id, lat: lat, lon: lon, name: name, url: url, enabled: enabled,
+                    lureExpireTimestamp: lureExpireTimestamp, lastModifiedTimestamp: lastModifiedTimestamp,
+                    updated: updated, questType: questType, questTarget: questTarget, questTimestamp: questTimestamp,
+                    questConditions: questConditions, questRewards: questRewards, questTemplate: questTemplate,
+                    questTitle: questTitle, cellId: cellId, lureId: lureId, sponsorId: sponsorId, partnerId: partnerId,
+                    arScanEligible: arScanEligible, powerUpPoints: powerUpPoints, powerUpLevel: powerUpLevel,
+                    powerUpEndTimestamp: powerUpEndTimestamp,
+                    alternativeQuestType: alternativeQuestType, alternativeQuestTarget: alternativeQuestTarget,
+                    alternativeQuestTimestamp: alternativeQuestTimestamp,
+                    alternativeQuestConditions: alternativeQuestConditions,
+                    alternativeQuestRewards: alternativeQuestRewards,
+                    alternativeQuestTemplate: alternativeQuestTemplate,
+                    alternativeQuestTitle: alternativeQuestTitle, incidents: incidents
+                )]) { (current, _) in current }
+            }
+        }
+        return Array(pokestops.values)
+    }
 }

--- a/Sources/RealDeviceMapLib/Modell/SpawnPoint.swift
+++ b/Sources/RealDeviceMapLib/Modell/SpawnPoint.swift
@@ -10,7 +10,6 @@
 import Foundation
 import PerfectLib
 import PerfectMySQL
-import POGOProtos
 
 public class SpawnPoint: JSONConvertibleObject {
 
@@ -120,7 +119,7 @@ public class SpawnPoint: JSONConvertibleObject {
         mysqlStmt.bindParam(despawnSecond)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[SPAWNPOINT] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[SPAWNPOINT] Failed to execute query in save(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -214,7 +213,7 @@ public class SpawnPoint: JSONConvertibleObject {
         mysqlStmt.bindParam(updated)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[SPAWNPOINT] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[SPAWNPOINT] Failed to execute query in getAll(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
         let results = mysqlStmt.results()
@@ -267,7 +266,7 @@ public class SpawnPoint: JSONConvertibleObject {
         mysqlStmt.bindParam(id)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[SPAWNPOINT] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[SPAWNPOINT] Failed to execute query in getWithId(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
         let results = mysqlStmt.results()

--- a/Sources/RealDeviceMapLib/Modell/User.swift
+++ b/Sources/RealDeviceMapLib/Modell/User.swift
@@ -186,7 +186,7 @@ public class User {
         mysqlStmt.bindParam(username)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in checkUsernameTaken(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -212,7 +212,7 @@ public class User {
         mysqlStmt.bindParam(email)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in checkEmailTaken(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -301,7 +301,7 @@ public class User {
         }
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in get(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -343,7 +343,7 @@ public class User {
         mysqlStmt.bindParam(discordId)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in get(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -392,7 +392,7 @@ public class User {
         _ = mysqlStmt.prepare(statement: sql)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in getAll(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -434,7 +434,7 @@ public class User {
         mysqlStmt.bindParam(username)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in setGroup(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -467,7 +467,7 @@ public class User {
         mysqlStmt.bindParam(username)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in setPassword(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
     }
@@ -499,7 +499,7 @@ public class User {
         mysqlStmt.bindParam(self.username)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in setUsername(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -549,12 +549,12 @@ public class User {
         mysqlStmtB.bindParam(username)
 
         guard mysqlStmtA.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmtA.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in setEmail(). (\(mysqlStmtA.errorMessage())")
             throw DBController.DBError()
         }
 
         guard mysqlStmtB.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmtB.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in setEmail(). (\(mysqlStmtB.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -591,7 +591,7 @@ public class User {
         mysqlStmtA.bindParam(id)
 
         guard mysqlStmtA.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmtA.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in setDiscordId(). (\(mysqlStmtA.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -627,7 +627,7 @@ public class User {
         mysqlStmtB.bindParam(id)
 
         guard mysqlStmtB.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmtB.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in setDiscordId(). (\(mysqlStmtB.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -643,7 +643,7 @@ public class User {
         mysqlStmtC.bindParam(username)
 
         guard mysqlStmtC.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmtC.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in setDiscordId(). (\(mysqlStmtC.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -680,7 +680,7 @@ public class User {
         mysqlStmtA.bindParam(username)
 
         guard mysqlStmtA.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmtA.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in verifyEmail(). (\(mysqlStmtA.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -689,7 +689,7 @@ public class User {
         mysqlStmtB.bindParam(username)
 
         guard mysqlStmtB.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmtB.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in verifyEmail(). (\(mysqlStmtB.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -718,7 +718,7 @@ public class User {
         mysqlStmt.bindParam(username)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in delete(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -758,7 +758,7 @@ public class User {
         mysqlStmt.bindParam(groupName)
 
         guard mysqlStmt.execute() else {
-            Log.error(message: "[User] Failed to execute query. (\(mysqlStmt.errorMessage())")
+            Log.error(message: "[User] Failed to execute query in save(). (\(mysqlStmt.errorMessage())")
             throw DBController.DBError()
         }
 
@@ -779,7 +779,7 @@ public class User {
                     if code != 250 {
                         Log.error(message: "[User] Failed to sent confirm email. Got code \(code)")
                     } else {
-                        Log.debug(message: "[User] Confirm email send successfully")
+                        Log.info(message: "[User] Confirm email send successfully")
                     }
             }
         }
@@ -799,7 +799,7 @@ public class User {
                     if code != 250 {
                         Log.error(message: "[User] Failed to sent reset password email. Got code \(code)")
                     } else {
-                        Log.debug(message: "[User] Reset password email send successfully")
+                        Log.info(message: "[User] Reset password email send successfully")
                     }
             }
         }

--- a/Sources/RealDeviceMapLib/Modell/Weather.swift
+++ b/Sources/RealDeviceMapLib/Modell/Weather.swift
@@ -12,6 +12,7 @@ import PerfectLib
 import PerfectMySQL
 import POGOProtos
 import S2Geometry
+import Turf
 
 public class Weather: JSONConvertibleObject, WebHookEvent {
 
@@ -220,6 +221,12 @@ public class Weather: JSONConvertibleObject, WebHookEvent {
                   oldWeather!.warnWeather != self.warnWeather {
             WebHookController.global.addWeatherEvent(weather: self)
         }
+    }
+
+    public static func findByLatLon(lat: Double, lon: Double) throws -> Weather? {
+        let centerCoord = LocationCoordinate2D(latitude: lat, longitude: lon)
+        let cellID = S2CellId(latlng: S2LatLng(coord: centerCoord)).parent(level: 10)
+        return try Weather.getWithId(id: cellID.id)
     }
 
     public static func getWithId(mysql: MySQL?=nil, id: Int64) throws -> Weather? {

--- a/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
@@ -248,7 +248,7 @@ public class WebRequestHandler {
                         }
                     }
                     if request.pathComponents[1] == "@pokestop" {
-                        if let pokestop = try Pokestop.getWithId(id: id) {
+                        if let pokestop = try Pokestop.getWithId(id: id, copy: true) {
                             if !perms.contains(.viewMapLure) {
                                 pokestop.lureId = nil
                                 pokestop.lureExpireTimestamp = nil
@@ -279,7 +279,7 @@ public class WebRequestHandler {
                         }
                     }
                     if request.pathComponents[1] == "@gym" {
-                        if let gym = try Gym.getWithId(id: id) {
+                        if let gym = try Gym.getWithId(id: id, copy: true) {
                             if !perms.contains(.viewMapRaid) {
                                 gym.raidEndTimestamp = nil
                                 gym.raidSpawnTimestamp = nil

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -598,7 +598,7 @@ public class WebHookRequestHandler {
                         account = nil
                     }
                     if account != nil {
-                        account!.responseInfo(accountData: playerdata)
+                        account!.updateFromResponseInfo(accountData: playerdata)
                         try? account!.save(mysql: mysql, update: true)
                     }
                 }

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -259,6 +259,11 @@ public class WebHookRequestHandler {
                 }
             } else if method == 101 {
                 if let fsr = try? FortSearchOutProto(serializedData: data) {
+                    if fsr.result != FortSearchOutProto.Result.success {
+                        Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Ignored non-success " +
+                            "FortSearchResponse: \(fsr.result)")
+                        continue
+                    }
                     if fsr.hasChallengeQuest && fsr.challengeQuest.hasQuest {
                         let hasAr = hasArQuestReqGlobal ??
                             hasArQuestReq ??
@@ -276,12 +281,22 @@ public class WebHookRequestHandler {
                 }
             } else if method == 102 && trainerLevel >= 30 || method == 102 && isMadData == true {
                 if let enr = try? EncounterOutProto(serializedData: data) {
+                    if enr.status != EncounterOutProto.Status.encounterSuccess {
+                        Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Ignored non-success " +
+                            "EncounterOutProto: \(enr.status)")
+                        continue
+                    }
                     encounters.append(enr)
                 } else {
                     Log.info(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Malformed EncounterResponse")
                 }
             } else if method == 145 && trainerLevel >= 30 || method == 145 && isMadData == true {
                 if processMapPokemon, let denr = try? DiskEncounterOutProto(serializedData: data) {
+                    if denr.result != DiskEncounterOutProto.Result.success {
+                        Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Ignored non-success " +
+                            "DiskEncounterOutProto: \(denr.result)")
+                        continue
+                    }
                     diskEncounters.append(denr)
                 } else {
                     Log.info(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Malformed DiskEncounterResponse")
@@ -294,6 +309,11 @@ public class WebHookRequestHandler {
                 }
             } else if method == 156 {
                 if let ggi = try? GymGetInfoOutProto(serializedData: data) {
+                    if ggi.result != GymGetInfoOutProto.Result.success {
+                        Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Ignored non-success " +
+                            "GymGetInfoResponse: \(ggi.result)")
+                        continue
+                    }
                     gymInfos.append(ggi)
                 } else {
                     Log.info(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Malformed GymGetInfoResponse")
@@ -301,6 +321,11 @@ public class WebHookRequestHandler {
             } else if method == 106 {
                 containsGMO = true
                 if let gmo = try? GetMapObjectsOutProto(serializedData: data) {
+                    if gmo.status != GetMapObjectsOutProto.Status.success {
+                        Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] Ignored non-success " +
+                            "GMO: \(gmo.status)")
+                        continue
+                    }
                     isInvalidGMO = false
 
                     var newWildPokemons = [(cell: UInt64, data: WildPokemonProto,
@@ -801,12 +826,6 @@ public class WebHookRequestHandler {
             if !encounters.isEmpty {
                 let start = Date()
                 for encounter in encounters {
-                    if encounter.status != EncounterOutProto.Status.encounterSuccess {
-                        Log.debug(
-                            message: "[WebHookRequestHandler] [\(uuid ?? "?")] Encounter no EncounterSuccess." +
-                                " encounter: \(encounter)")
-                        continue
-                    }
                     let pokemon: Pokemon?
                     do {
                         pokemon = try Pokemon.getWithId(
@@ -844,12 +863,6 @@ public class WebHookRequestHandler {
             if !diskEncounters.isEmpty {
                 let start = Date()
                 for diskEncounter in diskEncounters {
-                    if diskEncounter.result != DiskEncounterOutProto.Result.success {
-                        Log.debug(
-                            message: "[WebHookRequestHandler] [\(uuid ?? "?")] DiskEncounter no EncounterSuccess." +
-                                " diskEncounter: \(diskEncounter)")
-                        continue
-                    }
                     let displayId = diskEncounter.pokemon.pokemonDisplay.displayID
                     let displayIdCacheKey = UInt64(bitPattern: displayId).toString()
                     let pokemon: Pokemon?

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -19,6 +19,7 @@ public func setupRealDeviceMap() {
     let logLevel: String = ConfigLoader.global.getConfig(type: .logLevel)
     Log.even = true
     Log.setThreshold(value: logLevel)
+    Log.info(message: "[MAIN] Log level set to: \(logLevel)")
 
     if ProcessInfo.processInfo.environment["NO_INSTALL_BACKTRACE"] == nil {
         Log.info(message: "[MAIN] Installing Backtrace")
@@ -245,6 +246,21 @@ public func setupRealDeviceMap() {
     Log.info(message: "[MAIN] InstanceController require account in DB: \(InstanceController.requireAccountEnabled)")
     Log.info(message: "[MAIN] InstanceController Scan Lure Encounter: \(InstanceController.sendTaskForLureEncounter)")
     Log.info(message: "[MAIN] Login Limit enabled: \(WebHookRequestHandler.getLoginLimitConfig())")
+    Log.info(message: "[MAIN] Thread Limit Max: \(WebHookRequestHandler.threadLimitMax)")
+    let useRwForQuest: Bool = ConfigLoader.global.getConfig(type: .accUseRwForQuest)
+    Log.info(message: "[MAIN] Use RW Accounts for Quests: \(useRwForQuest)")
+    let useRwForRaid: Bool = ConfigLoader.global.getConfig(type: .accUseRwForRaid)
+    Log.info(message: "[MAIN] Use RW Accounts for Raids: \(useRwForRaid)")
+    let useRwForPokes: Bool = ConfigLoader.global.getConfig(type: .accUseRwForPokes)
+    Log.info(message: "[MAIN] Use RW Accounts for Pokemon: \(useRwForPokes)")
+    let skipBootstrap: Bool = ConfigLoader.global.getConfig(type: .stopAllBootstrapping)
+    Log.info(message: "[MAIN] Skip all bootstrapping: \(skipBootstrap)")
+    let limit = UInt8(exactly: ConfigLoader.global.getConfig(type: .questRetryLimit) as Int)!
+    Log.info(message: "[MAIN] Quest retry limit: \(limit)")
+    let spinDistance = Double(ConfigLoader.global.getConfig(type: .spinDistance) as Int)
+    Log.info(message: "[MAIN] Spin distance: \(spinDistance)")
+    let allowARQuests: Bool = ConfigLoader.global.getConfig(type: .allowARQuests)
+    Log.info(message: "[MAIN] Allow AR Quests: \(allowARQuests)")
 
     // Load Icon styles
     Log.info(message: "[MAIN] Load Icon Styles")

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -58,12 +58,14 @@ public func setupRealDeviceMap() {
             "[MAIN] Starting Memory Cache with interval \(memoryCacheClearInterval) " +
             "and keep time \(memoryCacheKeepTime)"
         )
+        Pokemon.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime,
+            extendTtlOnHit: false)
         Pokestop.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
-        Pokemon.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
         Gym.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
         SpawnPoint.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
         Weather.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
         Incident.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
+        Cell.cache = MemoryCache(interval: memoryCacheClearInterval, keepTime: memoryCacheKeepTime)
     } else {
         Log.info(message: "[MAIN] Memory Cache deactivated")
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - images:/app/resources/webroot/static/img
       - backups:/app/backups
       - /etc/localtime:/etc/localtime:ro
-#     - ./config.json:/app/resources/config/local.json # change relative path where config file is located
+#     - ./local.json:/app/resources/config/local.json # local.json usage
 #     - favicons:/app/resources/webroot/static/favicons
     ports:
       - 9000:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - images:/app/resources/webroot/static/img
       - backups:/app/backups
       - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
 #     - ./local.json:/app/resources/config/local.json # local.json usage
 #     - favicons:/app/resources/webroot/static/favicons
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   rdm:
-    image: docker.pkg.github.com/realdevicemap/realdevicemap/realdevicemap:master
+    image: ghcr.io/realdevicemap/realdevicemap/realdevicemap:master
     container_name: realdevicemap
     restart: unless-stopped
     tty: true

--- a/resources/config/default.json
+++ b/resources/config/default.json
@@ -42,7 +42,8 @@
     "account": {
       "requireInDB": true,
       "useRwForQuest": false,
-      "useRwForRaid": false
+      "useRwForRaid": false,
+      "useRwForPokes": false
     },
     "loginLimit": {
       "enabled": false,
@@ -72,6 +73,12 @@
     "webhook": {
       "endpointTimeout": 30,
       "endpointConnectTimeout": 30
-    }
+    },
+    "quest": {
+        "allowARQuests": true,
+        "questRetryLimit": 10,
+        "spinDistance": 80
+    },
+    "stopAllBootstrapping": false
   }
 }

--- a/resources/migrations/88.sql
+++ b/resources/migrations/88.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pokemon
+    ADD COLUMN `is_ditto` TINYINT(1) UNSIGNED NOT NULL DEFAULT FALSE after `display_pokemon_id`;


### PR DESCRIPTION
Changelog:

- ⚠️  DB-Migration on Pokemon table ⚠️ 
- Rework Pokemon Processing
  - weatherboosted (above L30) Ditto IV are cleared, because not correct
  - rework how pokemon proto are processed in general
  - make code more readable
- Rework Fort Processing
  - rework fort insert / update logic of gyms / pokestops (same like pokemon)
  - lures should not be extended anymore, when invasion occurs during lured is already active
  - improve the clearing of forts, actually the query is very exhaustive -> use s2cell cache to to compare fort count before deleting old stops/gyms
  - Pokemon cache TTL is not extended anymore on hit (every pokemon is maximum 60 minutes available, don't extend cache ttl for that key anymore, should decrease also mem size)
  - updating forts at least every 10 minutes if unchanged
- Add Status checks to Proto processing
  - ignore non-success proto
- Several Improvements
  - add config options, see default.json - like disable bootstrapping, don't use warned accounts for pokemon scanning, etc
  - change logging levels
  - update quest conditions and reward
  - don't update pokestop when clearing quests