### PR TITLE
Stop updating stops when clearing quests

### DIFF
--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -1088,7 +1088,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
 
         let sql = """
             UPDATE pokestop
-            SET updated = UNIX_TIMESTAMP(), quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
+            SET quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
                 quest_conditions = NULL, quest_rewards = NULL, quest_template = NULL, quest_title = NULL,
                 alternative_quest_type = NULL, alternative_quest_timestamp = NULL, alternative_quest_target = NULL,
                 alternative_quest_conditions = NULL, alternative_quest_rewards = NULL,
@@ -1141,7 +1141,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
         let coords = Pokestop.flattenCoords(area: areaString)
         let sql = """
             UPDATE pokestop
-            SET updated = UNIX_TIMESTAMP(), quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
+            SET quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
                 quest_conditions = NULL, quest_rewards = NULL, quest_template = NULL, quest_title = NULL,
                 alternative_quest_type = NULL, alternative_quest_timestamp = NULL, alternative_quest_target = NULL,
                 alternative_quest_conditions = NULL, alternative_quest_rewards = NULL,
@@ -1182,7 +1182,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
         let coords = Pokestop.flattenCoords(area: areaString)
         let sql = """
             UPDATE pokestop
-            SET updated = UNIX_TIMESTAMP(), quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
+            SET quest_type = NULL, quest_timestamp = NULL, quest_target = NULL,
                 quest_conditions = NULL, quest_rewards = NULL, quest_template = NULL, quest_title = NULL,
                 alternative_quest_type = NULL, alternative_quest_timestamp = NULL, alternative_quest_target = NULL,
                 alternative_quest_conditions = NULL, alternative_quest_rewards = NULL,


### PR DESCRIPTION
## Description
Thought this was added a while ago but it came back at some point. We do not need to set the `updated` value when clearing quests because the stops are not actually seen in game to warrant a change to `updated`. 

This also allows people to run queries based on the `updated` field to know when a stop has been removed or converted to a gym.

## How Has This Been Tested?
Running this on my local build.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

