### PR TITLE
DB Clearer - better approach

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/BinaryInteger.swift
+++ b/Sources/RealDeviceMapLib/Misc/BinaryInteger.swift
@@ -21,6 +21,9 @@ public extension BinaryInteger {
     func toUInt8() -> UInt8 {
         return UInt8(self)
     }
+    func toUInt() -> UInt {
+        return UInt(self)
+    }
     func toInt32() -> Int32 {
         return Int32(self)
     }
@@ -29,6 +32,9 @@ public extension BinaryInteger {
     }
     func toInt8() -> Int8 {
         return Int8(self)
+    }
+    func toDouble() -> Double {
+        return Double(self)
     }
     func toString() -> String {
         return self.description

--- a/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
+++ b/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
@@ -23,7 +23,7 @@ public class ConfigLoader {
         "USE_RW_FOR_QUEST", "USE_RW_FOR_RAID", "NO_GENERATE_IMAGES", "NO_PVP", "NO_IV_WEATHER_CLEARING",
         "NO_CELL_POKEMON", "SAVE_SPAWNPOINT_LASTSEEN", "NO_MEMORY_CACHE", "NO_BACKUP", "NO_REQUIRE_ACCOUNT",
         "SCAN_LURE_ENCOUNTER", "QUEST_RETRY_LIMIT", "SPIN_DISTANCE", "ALLOW_AR_QUESTS", "STOP_ALL_BOOTSTRAPPING",
-        "USE_RW_FOR_POKES"
+        "USE_RW_FOR_POKES", "NO_DB_CLEARER"
     ]
 
     private init() {
@@ -110,6 +110,20 @@ public class ConfigLoader {
             ?? defaultConfig.application.memoryCache.clearInterval.value()!
         case .memoryCacheKeepTime: return localConfig.application.memoryCache.keepTime.value()
             ?? defaultConfig.application.memoryCache.keepTime.value()!
+        case .dbClearerEnabled: return localConfig.application.clearer.enabled.value()
+            ?? defaultConfig.application.clearer.enabled.value()!
+        case .dbClearerPokemonInterval: return localConfig.application.clearer.pokemon.interval.value()
+            ?? defaultConfig.application.clearer.pokemon.interval.value()!
+        case .dbClearerPokemonKeepTime: return localConfig.application.clearer.pokemon.keepTime.value()
+            ?? defaultConfig.application.clearer.pokemon.keepTime.value()!
+        case .dbClearerPokemonBatchSize: return localConfig.application.clearer.pokemon.batchSize.value()
+            ?? defaultConfig.application.clearer.pokemon.batchSize.value()!
+        case .dbClearerIncidentInterval: return localConfig.application.clearer.incident.interval.value()
+            ?? defaultConfig.application.clearer.incident.interval.value()!
+        case .dbClearerIncidentKeepTime: return localConfig.application.clearer.incident.keepTime.value()
+            ?? defaultConfig.application.clearer.incident.keepTime.value()!
+        case .dbClearerIncidentBatchSize: return localConfig.application.clearer.incident.batchSize.value()
+            ?? defaultConfig.application.clearer.incident.batchSize.value()!
         case .pvpEnabled: return localConfig.application.pvp.enabled.value()
             ?? defaultConfig.application.pvp.enabled.value()!
         case .pvpLevelCaps: return localConfig.application.pvp.levelCaps.value()
@@ -172,6 +186,13 @@ public class ConfigLoader {
         case .memoryCacheEnabled: return false as! T
         case .memoryCacheClearInterval: return castValue(value: value)
         case .memoryCacheKeepTime: return castValue(value: value)
+        case .dbClearerEnabled: return false as! T // NO_DB_CLEARER
+        case .dbClearerPokemonInterval: return castValue(value: value)
+        case .dbClearerPokemonKeepTime: return castValue(value: value)
+        case .dbClearerPokemonBatchSize: return castValue(value: value)
+        case .dbClearerIncidentInterval: return castValue(value: value)
+        case .dbClearerIncidentKeepTime: return castValue(value: value)
+        case .dbClearerIncidentBatchSize: return castValue(value: value)
         case .pvpEnabled: return false as! T // NO_PVP
         case .pvpLevelCaps: return value.components(separatedBy: ",").map({ Int($0)! }) as! T
         case .pvpDefaultRank: return value as! T
@@ -191,6 +212,8 @@ public class ConfigLoader {
     private func castValue<T>(value: String) -> T {
         if T.self == UInt32.self {
             return UInt32(value.trimmingCharacters(in: .whitespaces)) as! T
+        } else if T.self == UInt.self {
+            return UInt(value.trimmingCharacters(in: .whitespaces)) as! T
         } else if T.self == Int.self {
             return Int(value.trimmingCharacters(in: .whitespaces)) as! T
         } else if T.self == Double.self {
@@ -235,6 +258,13 @@ public class ConfigLoader {
         case memoryCacheEnabled = "NO_MEMORY_CACHE"
         case memoryCacheClearInterval = "MEMORY_CACHE_CLEAR_INTERVAL"
         case memoryCacheKeepTime = "MEMORY_CACHE_KEEP_TIME"
+        case dbClearerEnabled = "NO_DB_CLEARER"
+        case dbClearerPokemonInterval = "DB_CLEARER_PO_INTERVAL" // not used in env
+        case dbClearerPokemonKeepTime = "DB_CLEARER_PO_KEEP_TIME" // not used in env
+        case dbClearerPokemonBatchSize = "DB_CLEARER_PO_BATCH_SIZE" // not used in env
+        case dbClearerIncidentInterval = "DB_CLEARER_IN_INTERVAL" // not used in env
+        case dbClearerIncidentKeepTime = "DB_CLEARER_IN_KEEP_TIME" // not used in env
+        case dbClearerIncidentBatchSize = "DB_CLEARER_IN_BATCH_SIZE" // not used in env
         case pvpEnabled = "NO_PVP"
         case pvpLevelCaps = "PVP_LEVEL_CAPS"
         case pvpDefaultRank = "PVP_DEFAULT_RANK"

--- a/Sources/RealDeviceMapLib/Misc/DBClearer.swift
+++ b/Sources/RealDeviceMapLib/Misc/DBClearer.swift
@@ -1,0 +1,114 @@
+//
+// Created by fabio on 13.09.22.
+//
+
+import Foundation
+import PerfectLib
+import PerfectMySQL
+import PerfectThread
+
+public class DBClearer {
+
+    static func startDatabaseArchiver() {
+        let interval = (ConfigLoader.global.getConfig(type: .dbClearerPokemonInterval) as Int).toDouble()
+        let keepTime = (ConfigLoader.global.getConfig(type: .dbClearerPokemonKeepTime) as Int).toDouble()
+        let batchSize = (ConfigLoader.global.getConfig(type: .dbClearerPokemonBatchSize) as Int).toUInt()
+        let statsEnabled = false // MARK: add config type
+        let message = statsEnabled ? "Created Stats and Archive in" : "Cleared in"
+
+        Threading.getQueue(name: "DatabaseArchiver", type: .serial).dispatch {
+            while true {
+                Threading.sleep(seconds: interval)
+                guard let mysql = DBController.global.mysql else {
+                    Log.error(message: "[DBClearer] [DatabaseArchiver] Failed to connect to database.")
+                    return
+                }
+                let start = Date()
+                if statsEnabled {
+                    let mysqlStmt = MySQLStmt(mysql)
+                    _ = mysqlStmt.prepare(statement: "CALL createStatsAndArchive();")
+                } else {
+                    clearPokemon(mysql: mysql, keepTime: keepTime, batchSize: batchSize)
+                }
+                Log.debug(message: "[DBClearer] [DatabaseArchiver] \(message) " +
+                    "\(String(format: "%.3f", Date().timeIntervalSince(start)))s")
+            }
+        }
+    }
+
+    static func startIncidentExpiry() {
+        let interval = (ConfigLoader.global.getConfig(type: .dbClearerIncidentInterval) as Int).toDouble()
+        let keepTime = (ConfigLoader.global.getConfig(type: .dbClearerIncidentKeepTime) as Int).toDouble()
+        let batchSize = (ConfigLoader.global.getConfig(type: .dbClearerIncidentBatchSize) as Int).toUInt()
+
+        Threading.getQueue(name: "IncidentExpiry", type: .serial).dispatch {
+            while true {
+                Threading.sleep(seconds: interval)
+                guard let mysql = DBController.global.mysql else {
+                    Log.error(message: "[DBClearer] [IncidentExpiry] Failed to connect to database.")
+                    return
+                }
+                let start = Date()
+                clearIncident(mysql: mysql, keepTime: keepTime, batchSize: batchSize)
+                Log.debug(message: "[DBClearer] [IncidentExpiry] Cleared in " +
+                    "\(String(format: "%.3f", Date().timeIntervalSince(start)))s")
+            }
+        }
+    }
+
+    private static func clearPokemon(mysql: MySQL, keepTime: Double, batchSize: UInt) {
+        var affectedRows: UInt = 0
+        var totalRows: UInt = 0
+        let sql = """
+                  DELETE FROM pokemon
+                  WHERE expire_timestamp <= UNIX_TIMESTAMP() - ?
+                  LIMIT ?;
+                  """
+
+        repeat {
+            let mysqlStmt = MySQLStmt(mysql)
+            _ = mysqlStmt.prepare(statement: sql)
+            mysqlStmt.bindParam(keepTime)
+            mysqlStmt.bindParam(batchSize)
+
+            guard mysqlStmt.execute() else {
+                Log.error(message: "[DBClearer] Failed to execute query 'DELETE LIMIT pokemon'. " +
+                    mysqlStmt.errorMessage())
+                break
+            }
+            affectedRows = mysqlStmt.affectedRows()
+            totalRows &+= affectedRows
+            // wait between batches
+            Threading.sleep(seconds: 0.2)
+        } while affectedRows == batchSize
+        Log.debug(message: "[DBClearer] Cleared \(totalRows) in DB table 'pokemon'")
+    }
+
+    private static func clearIncident(mysql: MySQL, keepTime: Double, batchSize: UInt) {
+        var affectedRows: UInt = 0
+        var totalRows: UInt = 0
+        let sql = """
+                  DELETE FROM incident
+                  WHERE expiration <= UNIX_TIMESTAMP() - ?
+                  LIMIT ?;
+                  """
+
+        repeat {
+            let mysqlStmt = MySQLStmt(mysql)
+            _ = mysqlStmt.prepare(statement: sql)
+            mysqlStmt.bindParam(keepTime)
+            mysqlStmt.bindParam(batchSize)
+
+            guard mysqlStmt.execute() else {
+                Log.error(message: "[DBClearer] Failed to execute query 'DELETE LIMIT incident'. " +
+                    mysqlStmt.errorMessage())
+                break
+            }
+            affectedRows = mysqlStmt.affectedRows()
+            totalRows &+= affectedRows
+            // wait between batches
+            Threading.sleep(seconds: 0.2)
+        } while affectedRows == batchSize
+        Log.debug(message: "[DBClearer] Cleared \(totalRows) in DB table 'incident'")
+    }
+}

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -916,8 +916,6 @@ public class WebHookRequestHandler {
                 for (cellId, stopIds) in stopsIdsPerCell {
                     let cachedCell = Cell.cache?.get(id: cellId.toString())
                     if cachedCell?.stopCount != stopIds.count {
-                        Log.debug(message: "[WebHookRequestHandler] Clearing old stops in \(cellId): " +
-                            "\(cachedCell?.stopCount ?? 0) != \(stopIds.count)")
                         if let cleared = try? Pokestop.clearOld(mysql: mysql, ids: stopIds, cellId: cellId),
                            cleared != 0 {
                             Log.info(message: "[WebHookRequestHandler] [\(uuid ?? "?")] " +

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -52,8 +52,8 @@ public func setupRealDeviceMap() {
 
     // Init MemoryCache
     let memoryCacheEnabled: Bool = ConfigLoader.global.getConfig(type: .memoryCacheEnabled)
-    let memoryCacheClearInterval = Double(ConfigLoader.global.getConfig(type: .memoryCacheClearInterval) as Int)
-    let memoryCacheKeepTime = Double(ConfigLoader.global.getConfig(type: .memoryCacheKeepTime) as Int)
+    let memoryCacheClearInterval = (ConfigLoader.global.getConfig(type: .memoryCacheClearInterval) as Int).toDouble()
+    let memoryCacheKeepTime = (ConfigLoader.global.getConfig(type: .memoryCacheKeepTime) as Int).toDouble()
     if memoryCacheEnabled {
         Log.info(message:
             "[MAIN] Starting Memory Cache with interval \(memoryCacheClearInterval) " +
@@ -308,6 +308,18 @@ public func setupRealDeviceMap() {
         let message = "[MAIN] Failed to start Assignment Controller"
         Log.critical(message: message)
         fatalError(message)
+    }
+
+    // Start Clearer
+    if ConfigLoader.global.getConfig(type: .dbClearerEnabled) as Bool {
+        // Stats.interval = (ConfigLoader.global.getConfig(type: .dbClearerInterval) as Int).toDouble()
+        // Stats.keepTime = (ConfigLoader.global.getConfig(type: .dbClearerKeepTime) as Int).toDouble()
+        // Stats.batchSize = (ConfigLoader.global.getConfig(type: .dbClearerBatchSize) as Int).toUInt()
+        Log.info(message: "[TMP] Start Database Archiver")
+        DBClearer.startDatabaseArchiver()
+        Log.info(message: "[TMP] Start Incident Expiry")
+        DBClearer.startIncidentExpiry()
+        Log.info(message: "[TMP] Successful")
     }
 
     // Check if is setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,12 @@ services:
 #     PVP_GREAT_FILTER: 1400
 #     PVP_ULTRA_FILTER: 2350
 #     PVP_LEVEL_CAPS: 40,50,51 #default only 50
+#     QUEST_RETRY_LIMIT: 10
+#     SPIN_DISTANCE: 80
 ### Uncommenting the following lines will set these values to TRUE (regardless of their value)
 #     USE_RW_FOR_QUEST: 1
 #     USE_RW_FOR_RAID: 1
+#     USE_RW_FOR_POKES: 1
 #     NO_GENERATE_IMAGES: 1
 #     NO_PVP: 1
 #     NO_IV_WEATHER_CLEARING: 1
@@ -53,6 +56,8 @@ services:
 #     SAVE_SPAWNPOINT_LASTSEEN: 1
 #     NO_MEMORY_CACHE: 1
 #     NO_BACKUP: 1
+#     NO_DB_CLEARER: 1
+#     STOP_ALL_BOOTSTRAPPING: 1
 #     NO_REQUIRE_ACCOUNT: 1
 ### Uncommenting The following lines will start RDM in lldb and show crash reports in logs
 ### Running in lldb will use more resources, but RDM will run as usual.

--- a/resources/config/default.json
+++ b/resources/config/default.json
@@ -62,6 +62,19 @@
       "clearInterval": 900,
       "keepTime": 3600
     },
+    "clearer": {
+      "enabled": true,
+      "pokemon": {
+        "interval": 300,
+        "keepTime": 3600,
+        "batchSize": 250
+      },
+      "incident": {
+        "interval": 900,
+        "keepTime": 3600,
+        "batchSize": 250
+      }
+    },
     "pvp": {
       "enabled": true,
       "levelCaps": [50],

--- a/resources/migrations/89.sql
+++ b/resources/migrations/89.sql
@@ -1,0 +1,2 @@
+create index ix_expiration
+    on incident (expiration);


### PR DESCRIPTION
replaces #405 

Clears growing tables (pokemon, incident/invasion) of RDM during run time

It uses DELETE LIMIT and batchsizes to delete.
Little and often, does the trick to find a good algorithm.