### PR TITLE
use first IP for host if multiple IPs contained in Header

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/HTTPRequest.swift
+++ b/Sources/RealDeviceMapLib/Misc/HTTPRequest.swift
@@ -15,7 +15,11 @@ internal extension HTTPRequest {
         if forwardedForHeader.isEmpty || !WebHookRequestHandler.hostWhitelistUsesProxy {
             hostString = self.remoteAddress.host
         } else {
-            hostString = forwardedForHeader.components(separatedBy: ",").first!.trimmingCharacters(in: .whitespaces)
+            if forwardedForHeader.contains(",") {
+                hostString = forwardedForHeader.components(separatedBy: ",").first!.trimmingCharacters(in: .whitespaces)
+            } else {
+                hostString = forwardedForHeader
+            }
         }
         let hexParts = hostString.components(separatedBy: ":")
         if hexParts.count == 8 {

--- a/Sources/RealDeviceMapLib/Misc/HTTPRequest.swift
+++ b/Sources/RealDeviceMapLib/Misc/HTTPRequest.swift
@@ -15,7 +15,7 @@ internal extension HTTPRequest {
         if forwardedForHeader.isEmpty || !WebHookRequestHandler.hostWhitelistUsesProxy {
             hostString = self.remoteAddress.host
         } else {
-            hostString = forwardedForHeader
+            hostString = forwardedForHeader.components(separatedBy: ",").first!.trimmingCharacters(in: .whitespaces)
         }
         let hexParts = hostString.components(separatedBy: ":")
         if hexParts.count == 8 {


### PR DESCRIPTION
this improves the login limit handling

`135.XXX.XXX.XXX, 172.68.XXX.XXX` login limiter can not work with a list of IPs... Therefore we only use the first IP (proxy ip does append last), this is external IP and the most important for login limit