### PR TITLE
MITM communication

### DIFF
--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/AutoInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/AutoInstanceController.swift
@@ -435,7 +435,7 @@ class AutoInstanceController: InstanceControllerProto {
                             "min_level": minLevel, "max_level": maxLevel]
                 } else {
                     bootstrappLock.unlock()
-                    return [String: Any]()
+                    return [:]
                 }
 
             } else {
@@ -525,7 +525,7 @@ class AutoInstanceController: InstanceControllerProto {
                     Log.error(
                         message: "[AutoInstanceController] [\(name)] [\(uuid)] Failed to get last location."
                     )
-                    return [String: Any]()
+                    return [:]
                 }
 
                 if lastCoord != nil {
@@ -542,7 +542,7 @@ class AutoInstanceController: InstanceControllerProto {
                     let todayStopsC = todayStops
                     stopsLock.unlock()
                     if todayStopsC!.isEmpty {
-                        return [String: Any]()
+                        return [:]
                     }
 
                     for stop in todayStopsC! {
@@ -644,7 +644,7 @@ class AutoInstanceController: InstanceControllerProto {
                     stopsLock.lock()
                     todayStops?.append(pokestop)
                     stopsLock.unlock()
-                    return [String: Any]()
+                    return [:]
                 }
 
                 if delay >= delayLogout && account != nil {
@@ -702,7 +702,7 @@ class AutoInstanceController: InstanceControllerProto {
                     stopsLock.lock()
                     todayStops?.append(pokestop)
                     stopsLock.unlock()
-                    return [String: Any]()
+                    return [:]
                 }
 
                 stopsLock.lock()

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleSmartRaidInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/CircleSmartRaidInstanceController.swift
@@ -158,7 +158,7 @@ class CircleSmartRaidInstanceController: CircleInstanceController {
         smartRaidLock.unlock()
 
         if coord == nil {
-            return [String: Any]()
+            return [:]
         } else {
             self.statsLock.lock()
             if self.startDate == nil {

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/IVInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/IVInstanceController.swift
@@ -142,7 +142,7 @@ class IVInstanceController: InstanceControllerProto {
         pokemonLock.lock()
         if pokemonQueue.isEmpty {
             pokemonLock.unlock()
-            return [String: Any]()
+            return [:]
         }
         let pokemon = pokemonQueue.removeFirst()
         pokemonLock.unlock()

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/LevelingInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/LevelingInstanceController.swift
@@ -140,7 +140,7 @@ class LevelingInstanceController: InstanceControllerProto {
             encounterTime = result.encounterTime
         } catch {
             Log.error(message: "[LevelingInstanceController] [\(name)] [\(uuid)] Failed to calculate cooldown.")
-            return [String: Any]()
+            return [:]
         }
 
         do {
@@ -153,7 +153,7 @@ class LevelingInstanceController: InstanceControllerProto {
           )
         } catch {
             Log.error(message: "[LevelingInstanceController] [\(name)] [\(uuid)] Failed to store cooldown.")
-            return [String: Any]()
+            return [:]
         }
 
         playerLock.lock()

--- a/Sources/RealDeviceMapLib/Misc/HTTPResponse.swift
+++ b/Sources/RealDeviceMapLib/Misc/HTTPResponse.swift
@@ -17,6 +17,12 @@ extension HTTPResponse {
         completed(status: status)
     }
 
+    public func respondWithError(event: WebHookRequestHandler.Event) {
+        _ = try? setBody(json: ["status": "error", "error": event.rawValue])
+        setHeader(.contentType, value: "application/json")
+        completed()
+    }
+
     func respondWithData(data: JSONConvertible) throws {
         try setBody(json: ["status": "ok", "data": data])
         setHeader(.contentType, value: "application/json")

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1045,7 +1045,7 @@ public class WebHookRequestHandler {
                         account: account, timestamp: timestamp
                     )
                     if task.isEmpty {
-                        try response.respondWithError(event: .taskNotFound)
+                        response.respondWithError(event: .taskNotFound)
                     }
                     Log.info(
                         message: "[WebHookRequestHandler] [\(uuid)] Sending task: \(task["action"] as? String ?? "?")" +

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1045,7 +1045,7 @@ public class WebHookRequestHandler {
                         account: account, timestamp: timestamp
                     )
                     if task.isEmpty {
-                        response.respondWithError(event: .taskNotFound)
+                        response.respondWithError(event: .noTaskLeft)
                     }
                     Log.info(
                         message: "[WebHookRequestHandler] [\(uuid)] Sending task: \(task["action"] as? String ?? "?")" +
@@ -1083,7 +1083,7 @@ public class WebHookRequestHandler {
                     guard let newAccount = try InstanceController.global.getAccount(mysql: mysql, deviceUUID: uuid)
                     else {
                         Log.error(message: "[WebHookRequestHandler] [\(uuid)] Failed to get account for \(uuid)")
-                        response.respondWithError(event: .accountNotFound)
+                        response.respondWithError(event: .noAccountLeft)
                         return
                     }
                     account = newAccount
@@ -1319,8 +1319,9 @@ public class WebHookRequestHandler {
 
     public enum Event: String {
         case accountNotFound
+        case noAccountLeft
         case deviceNotFound
         case instanceNotFound
-        case taskNotFound
+        case noTaskLeft
     }
 }

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1044,6 +1044,9 @@ public class WebHookRequestHandler {
                         mysql: mysql, uuid: uuid, username: username,
                         account: account, timestamp: timestamp
                     )
+                    if task.isEmpty {
+                        try response.respondWithError(event: .taskNotFound)
+                    }
                     Log.info(
                         message: "[WebHookRequestHandler] [\(uuid)] Sending task: \(task["action"] as? String ?? "?")" +
                         " at \((task["lat"] as? Double)?.description ?? "?")," +
@@ -1054,12 +1057,12 @@ public class WebHookRequestHandler {
                     response.respondWithError(status: .internalServerError)
                 }
             } else {
-                response.respondWithError(status: .notFound)
+                response.respondWithError(event: .instanceNotFound)
             }
         } else if type == "get_account" {
             do {
                 guard let device = try Device.getById(mysql: mysql, id: uuid) else {
-                    response.respondWithError(status: .notFound)
+                    response.respondWithError(event: .deviceNotFound)
                     return
                 }
                 var account: Account?
@@ -1080,7 +1083,7 @@ public class WebHookRequestHandler {
                     guard let newAccount = try InstanceController.global.getAccount(mysql: mysql, deviceUUID: uuid)
                     else {
                         Log.error(message: "[WebHookRequestHandler] [\(uuid)] Failed to get account for \(uuid)")
-                        response.respondWithError(status: .notFound)
+                        response.respondWithError(event: .accountNotFound)
                         return
                     }
                     account = newAccount
@@ -1185,7 +1188,7 @@ public class WebHookRequestHandler {
                     let username = username,
                     let account = try Account.getWithUsername(mysql: mysql, username: username)
                     else {
-                        response.respondWithError(status: .notFound)
+                        response.respondWithError(event: .accountNotFound)
                         return
                 }
                 let now = UInt32(Date().timeIntervalSince1970)
@@ -1210,7 +1213,7 @@ public class WebHookRequestHandler {
                     let username = device.accountUsername,
                     let account = try Account.getWithUsername(mysql: mysql, username: username)
                     else {
-                        response.respondWithError(status: .notFound)
+                        response.respondWithError(event: .accountNotFound)
                         return
                 }
                 if account.failedTimestamp == nil || account.failed == nil {
@@ -1233,7 +1236,7 @@ public class WebHookRequestHandler {
                     let username = device.accountUsername,
                     let account = try Account.getWithUsername(mysql: mysql, username: username)
                 else {
-                    response.respondWithError(status: .notFound)
+                    response.respondWithError(event: .accountNotFound)
                     return
                 }
                 var accountShouldBeDisabled = false
@@ -1271,7 +1274,7 @@ public class WebHookRequestHandler {
                 guard
                     let device = try Device.getById(mysql: mysql, id: uuid)
                 else {
-                    response.respondWithError(status: .notFound)
+                    response.respondWithError(event: .deviceNotFound)
                     return
                 }
                 device.accountUsername = nil
@@ -1312,5 +1315,12 @@ public class WebHookRequestHandler {
 
     static func getLoginLimitConfig() -> String {
         return "\(loginLimitEnabled) - \(loginLimit)/\(loginLimitIntervall)"
+    }
+
+    enum Event: String {
+        case accountNotFound
+        case deviceNotFound
+        case instanceNotFound
+        case taskNotFound
     }
 }

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1317,7 +1317,7 @@ public class WebHookRequestHandler {
         return "\(loginLimitEnabled) - \(loginLimit)/\(loginLimitIntervall)"
     }
 
-    enum Event: String {
+    public enum Event: String {
         case accountNotFound
         case deviceNotFound
         case instanceNotFound


### PR DESCRIPTION
provide better error events on account fetching.

RDM should not return http 404 when account is not found, it should return 200 with proper error codes... needs testing with MITM.... I am in contact with devs.

e.g.
```json
{
  "status": "error",
  "error": "accountNotFound"
}
```
Possible error events:
- accountNotFound
- noAccountLeft
- deviceNotFound
- instanceNotFound
 - noTaskLeft