### PR TITLE
fix myslq connection of DBClearer

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/DBClearer.swift
+++ b/Sources/RealDeviceMapLib/Misc/DBClearer.swift
@@ -21,7 +21,7 @@ public class DBClearer {
                 Threading.sleep(seconds: interval)
                 guard let mysql = DBController.global.mysql else {
                     Log.error(message: "[DBClearer] [DatabaseArchiver] Failed to connect to database.")
-                    return
+                    continue
                 }
                 let start = Date()
                 if statsEnabled {
@@ -46,7 +46,7 @@ public class DBClearer {
                 Threading.sleep(seconds: interval)
                 guard let mysql = DBController.global.mysql else {
                     Log.error(message: "[DBClearer] [IncidentExpiry] Failed to connect to database.")
-                    return
+                    continue
                 }
                 let start = Date()
                 clearIncident(mysql: mysql, keepTime: keepTime, batchSize: batchSize)


### PR DESCRIPTION
Sometimes thread lost db Connection, when e.g. db server restarted... It now retries, instead of exiting thread