### PR TITLE
Pokestop UICON functionality for incident display type and power-up

### DIFF
--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -1374,7 +1374,8 @@ public class ApiRequestHandler {
                         "sort": i+10
                     ],
                     "name": powerUpLevel,
-                    "image": "<img class=\"lazy_load\" data-src=\"/image-api/pokestop?style=\(iconStyle)&id=0\" " +
+                    "image": "<img class=\"lazy_load\" data-src=\"/image-api/pokestop?style=\(iconStyle)&id=0" +
+                        "&ar=true&power_up_level=\(i)\" " +
                         "style=\"height:50px; width:50px;\">",
                     "filter": powerUpFilter,
                     "size": powerUpSize,

--- a/Sources/RealDeviceMapLib/ImageAPI/ImageApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/ImageAPI/ImageApiRequestHandler.swift
@@ -107,9 +107,10 @@ class ImageApiRequestHandler {
               let id = request.param(name: "id")?.toInt() else {
             return response.respondWithError(status: .badRequest)
         }
-        let invasionActive = request.param(name: "invasion")?.toBool() ?? false
-        let gruntType = request.param(name: "grunt_type")?.toInt()
+        let incidentCharacter = request.param(name: "incident_character")?.toInt()
+        let incidentDisplayType = request.param(name: "incident_display_type")?.toInt()
         let questActive = request.param(name: "quest")?.toBool() ?? false
+        let arEligible = request.param(name: "ar")?.toBool() ?? false
         let questRewardType = request.param(name: "quest_reward_type")?.toInt()
         let questItemId = request.param(name: "quest_item_id")
         let questRewardAmount = request.param(name: "quest_reward_amount")?.toInt()
@@ -117,10 +118,12 @@ class ImageApiRequestHandler {
         let questFormId = request.param(name: "quest_form_id")?.toInt()
         let questGenderId = request.param(name: "quest_gender_id")?.toInt()
         let questCostumeId = request.param(name: "quest_costume_id")?.toInt()
+        let powerUpLevel = request.param(name: "power_up_level")?.toInt()
 
         var invasion: ImageManager.Invasion?
-        if gruntType != nil {
-            invasion = ImageManager.Invasion(style: style, id: gruntType!)
+        if incidentCharacter != nil && (incidentDisplayType ?? Int.max) < 7 {
+            // only create rocket invasion and npc
+            invasion = ImageManager.Invasion(style: style, id: incidentCharacter!)
         }
         var reward: ImageManager.Reward?
         var pokemon: ImageManager.Pokemon?
@@ -136,8 +139,9 @@ class ImageApiRequestHandler {
                     amount: questRewardAmount, type: protosQuestRewardType)
             }
         }
-        let pokestop = ImageManager.Pokestop(style: style, id: id, invasionActive: invasionActive,
-            questActive: questActive, invasion: invasion, reward: reward, pokemon: pokemon)
+        let pokestop = ImageManager.Pokestop(style: style, id: id, arEligible: arEligible,
+            incidentDisplayType: incidentDisplayType, questActive: questActive, powerUpLevel: powerUpLevel,
+            invasion: invasion, reward: reward, pokemon: pokemon)
         let file = ImageManager.global.findPokestopImage(pokestop: pokestop)
         sendFile(response: response, file: file)
     }

--- a/Sources/RealDeviceMapLib/Misc/ImageManager.swift
+++ b/Sources/RealDeviceMapLib/Misc/ImageManager.swift
@@ -570,8 +570,9 @@ extension ImageManager {
         var id: Int // Not lured is ID 0
         var arEligible: Bool = false
         var sponsor: Bool = false
-        var invasionActive: Bool = false
+        var incidentDisplayType: Int?
         var questActive: Bool = false
+        var powerUpLevel: Int?
 
         // Generated
         var invasion: Invasion?
@@ -583,9 +584,18 @@ extension ImageManager {
 
         var postfixes: [String] {
             var build: [String] = []
-            if invasionActive { build.append("i") }
+            if incidentDisplayType != nil {
+                if incidentDisplayType! < 7 {
+                    build.append("i")
+                } else {
+                    build.append("i\(incidentDisplayType!)")
+                }
+            }
             if questActive { build.append("q") }
             if arEligible { build.append("ar") }
+            if powerUpLevel != nil {
+                build.append("p\(powerUpLevel!)")
+            }
             return build
         }
         var uicon: String {

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -822,7 +822,11 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
         }
 
         if pokestopShowOnlyEvent && showPokestops {
-            onlyEventSQL = "AND display_type = 7 "
+            if showInvasions {
+                onlyEventSQL = "AND display_type IS NOT NULL "
+            } else {
+                onlyEventSQL = "AND display_type >= 7 "
+            }
         } else {
             onlyEventSQL = ""
         }
@@ -900,7 +904,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
         }
         let results = mysqlStmt.results()
         return extractResults(results: results, showLures: showLures, showInvasions: showInvasions,
-            showQuests: showQuests)
+            showOnlyEvent: pokestopShowOnlyEvent, showQuests: showQuests)
 
     }
 
@@ -1452,7 +1456,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
     }
 
     private static func extractResults(results: MySQLStmt.Results, showLures: Bool = true, showInvasions: Bool = true,
-                                       showQuests: Bool = true) -> [Pokestop] {
+                                       showOnlyEvent: Bool = false, showQuests: Bool = true) -> [Pokestop] {
         var pokestops = [String: Pokestop]()
         while let result = results.next() {
             let id = result[0] as! String
@@ -1533,7 +1537,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
             let powerUpEndTimestamp = result[31] as? UInt32
 
             let incident: Incident?
-            if showInvasions {
+            if showInvasions || showOnlyEvent {
                 let incidentId = result[32] as? String
                 if incidentId != nil {
                     let pokestopId = result[33] as! String

--- a/resources/webroot/index.js.mustache
+++ b/resources/webroot/index.js.mustache
@@ -3487,7 +3487,7 @@ function getPokestopMarkerIcon (pokestop, ts) {
   let itemId
   let pokemonId
   let formId, genderId, costumeId
-  let lureId, invasionGruntType
+  let lureId, invasionGruntType, incidentDisplayType
   var size = 20
 
   if ((showQuests || pokestop.is_start) && (
@@ -3530,12 +3530,15 @@ function getPokestopMarkerIcon (pokestop, ts) {
     size = lureSize
   }
 
-  if ((pokestop.is_start || showInvasions === true) && pokestop.incidents && pokestop.incidents.length > 0) {
-    invasionGruntType = Math.min.apply(Math, pokestop.incidents.map(function(incident) { return incident.character; }))
-    let invasionSize = getInvasionSize(invasionGruntType)
-    if (invasionSize > size) {
-      size = invasionSize
+  if (pokestop.incidents && pokestop.incidents.length > 0) {
+    if (pokestop.is_start || showInvasions === true) {
+      invasionGruntType = Math.min.apply(Math, pokestop.incidents.map(function(incident) { return incident.character; }))
+      let invasionSize = getInvasionSize(invasionGruntType)
+      if (invasionSize > size) {
+        size = invasionSize
+      }
     }
+    incidentDisplayType = Math.min.apply(Math, pokestop.incidents.map(function(incident) { return incident.display_type; }))
   }
   let multiplierSize = 1
   let multiplierAnchor = 1
@@ -3545,7 +3548,7 @@ function getPokestopMarkerIcon (pokestop, ts) {
   }
 
   let icon = L.icon({
-    iconUrl: getPokestopIconURL(lureId,invasionGruntType, rewardType, rewardAmount, itemId, pokemonId, formId, costumeId, genderId),
+    iconUrl: getPokestopIconURL(lureId, incidentDisplayType, invasionGruntType, rewardType, rewardAmount, itemId, pokemonId, formId, costumeId, genderId),
     iconSize: [size, size * multiplierSize],
     iconAnchor: [size / 2, size * multiplierAnchor],
     popupAnchor: [0, size * -1.567],
@@ -4828,10 +4831,13 @@ function getPokemonIconURL(pokemonId, pokemonForm, pokemonCostume, pokemonGender
   return response
 }
 
-function getPokestopIconURL(lureId, invasionGruntType, rewardType, rewardAmount, itemId, pokemonId, formId, costumeId, genderId) {
+function getPokestopIconURL(lureId, incidentDisplayType, invasionGruntType, rewardType, rewardAmount, itemId, pokemonId, formId, costumeId, genderId) {
   var response = '/image-api/pokestop?style=' + selectedIconStyle + '&id=' + lureId
+  if (incidentDisplayType) {
+    response += '&incident_display_type=' + incidentDisplayType
+  }
   if (invasionGruntType) {
-    response += '&invasion=true&grunt_type=' + invasionGruntType
+    response += '&incident_character=' + invasionGruntType
   }
   if (rewardType) {
     response += '&quest_reward_type=' + rewardType


### PR DESCRIPTION
Add functionality for UICON:
- power-up-level of pokestop
- incident display type to show golden or kecleon stops (part in pokestop filter - show only event stops)

![image](https://user-images.githubusercontent.com/35898099/211281221-6ce0712c-701f-4e55-83dd-08845a4e1c27.png)

![image](https://user-images.githubusercontent.com/35898099/211281296-e8eca7f9-fa80-4791-a06c-6e329f72c106.png)
