### PR TITLE
Rework Pokemon Count Stats

### DIFF
--- a/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/API/ApiRequestHandler.swift
@@ -2099,7 +2099,7 @@ public class ApiRequestHandler {
 
         let permViewStats = perms.contains(.viewStats)
         if permViewStats && showDashboardStats {
-            let stats = Stats().getJSONValues()
+            let stats = Stats.global.getJSONValues()
             data["pokemon_total"] = stats["pokemon_total"]
             data["pokemon_iv_total"] = stats["pokemon_iv_total"]
             data["pokemon_total_shiny"] = stats["pokemon_total_shiny"]

--- a/Sources/RealDeviceMapLib/Misc/BinaryInteger.swift
+++ b/Sources/RealDeviceMapLib/Misc/BinaryInteger.swift
@@ -24,6 +24,9 @@ public extension BinaryInteger {
     func toUInt() -> UInt {
         return UInt(self)
     }
+    func toInt() -> Int {
+        return Int(self)
+    }
     func toInt32() -> Int32 {
         return Int32(self)
     }

--- a/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
+++ b/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
@@ -126,8 +126,12 @@ public class ConfigLoader {
             ?? defaultConfig.application.clearer.incident.keepTime.value()!
         case .dbClearerIncidentBatchSize: return localConfig.application.clearer.incident.batchSize.value()
             ?? defaultConfig.application.clearer.incident.batchSize.value()!
-        case .statsEnabled: return localConfig.application.stats.value()
-            ?? defaultConfig.application.stats.value()!
+        case .statsPokemonArchiveEnabled: return localConfig.application.stats.pokemon.archive.value()
+            ?? defaultConfig.application.stats.pokemon.archive.value()!
+        case .statsPokemonTimingEnabled: return localConfig.application.stats.pokemon.timing.value()
+            ?? defaultConfig.application.stats.pokemon.timing.value()!
+        case .statsPokemonCountEnabled: return localConfig.application.stats.pokemon.count.value()
+            ?? defaultConfig.application.stats.pokemon.count.value()!
         case .pvpEnabled: return localConfig.application.pvp.enabled.value()
             ?? defaultConfig.application.pvp.enabled.value()!
         case .pvpLevelCaps: return localConfig.application.pvp.levelCaps.value()
@@ -198,7 +202,9 @@ public class ConfigLoader {
         case .dbClearerIncidentInterval: return castValue(value: value)
         case .dbClearerIncidentKeepTime: return castValue(value: value)
         case .dbClearerIncidentBatchSize: return castValue(value: value)
-        case .statsEnabled: return castValue(value: value)
+        case .statsPokemonArchiveEnabled: return castValue(value: value)
+        case .statsPokemonTimingEnabled: return castValue(value: value)
+        case .statsPokemonCountEnabled: return castValue(value: value)
         case .pvpEnabled: return false as! T // NO_PVP
         case .pvpLevelCaps: return value.components(separatedBy: ",").map({ Int($0)! }) as! T
         case .pvpDefaultRank: return value as! T
@@ -272,7 +278,9 @@ public class ConfigLoader {
         case dbClearerIncidentInterval = "DB_CLEARER_IN_INTERVAL" // not used in env
         case dbClearerIncidentKeepTime = "DB_CLEARER_IN_KEEP_TIME" // not used in env
         case dbClearerIncidentBatchSize = "DB_CLEARER_IN_BATCH_SIZE" // not used in env
-        case statsEnabled = "STATS" // not used in env
+        case statsPokemonArchiveEnabled = "STATS_ARCHIVE_POKEMON" // not used in env
+        case statsPokemonTimingEnabled = "STATS_TIMING_POKEMON" // not used in env
+        case statsPokemonCountEnabled = "STATS_COUNT_POKEMON" // not used in env
         case pvpEnabled = "NO_PVP"
         case pvpLevelCaps = "PVP_LEVEL_CAPS"
         case pvpDefaultRank = "PVP_DEFAULT_RANK"

--- a/Sources/RealDeviceMapLib/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokemon.swift
@@ -30,7 +30,7 @@ public class Pokemon: JSONConvertibleObject, NSCopying, WebHookEvent, Equatable,
     public static var weatherIVClearingEnabled = true
     public static var cellPokemonEnabled = true
     public static var saveSpawnpointLastSeen = false
-    public static var statsEnabled = false
+    public static var timingStatsEnabled = false
 
     public static var cache: MemoryCache<Pokemon>?
     public static var diskEncounterCache: MemoryCache<DiskEncounterOutProto>?
@@ -1151,7 +1151,7 @@ public class Pokemon: JSONConvertibleObject, NSCopying, WebHookEvent, Equatable,
     }
 
     private func updateStats(mysql: MySQL, id: String, event: String) throws {
-        if !Pokemon.statsEnabled {
+        if !Pokemon.timingStatsEnabled {
             return
         }
         let sql: String

--- a/Sources/RealDeviceMapLib/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokemon.swift
@@ -298,7 +298,8 @@ public class Pokemon: JSONConvertibleObject, NSCopying, WebHookEvent, Equatable,
         setPokemonDisplay(pokemonId: pokemonId, display: nearbyPokemon.pokemonDisplay)
 
         if id == "" {
-            try? updateTimingStats(mysql: mysql, id: encounterId, event: (pokestopId.isEmpty ? statsSeenCell : statsSeenStop))
+            let event = (pokestopId.isEmpty ? statsSeenCell : statsSeenStop)
+            try? updateTimingStats(mysql: mysql, id: encounterId, event: event)
         }
 
         if isDitto {

--- a/Sources/RealDeviceMapLib/Modell/Pokemon.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokemon.swift
@@ -758,6 +758,7 @@ public class Pokemon: JSONConvertibleObject, NSCopying, WebHookEvent, Equatable,
 
         Pokemon.createPokemonWebhooks(old: oldPokemon, new: self)
         Stats.global.updatePokemonCountStats(old: oldPokemon, new: self)
+
         if oldPokemon == nil {
             InstanceController.global.gotPokemon(pokemon: self)
             if self.atkIv != nil {

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -12,7 +12,7 @@ import PerfectLib
 import PerfectMySQL
 import PerfectThread
 
-class Stats: JSONConvertibleObject {
+class Stats {
 
     public static let global = Stats()
 
@@ -246,7 +246,7 @@ class Stats: JSONConvertibleObject {
         }
         values += "(?,?,?) "
 
-        var sql = """
+        let sql = """
                   INSERT INTO \(table) (date, pokemon_id, `count`) VALUES \(values)
                   ON DUPLICATE KEY UPDATE `count` = `count` + VALUES(`count`)
                   """
@@ -290,7 +290,7 @@ class Stats: JSONConvertibleObject {
     // Stats related to triggers, stats page
     // =================================================================================================================
 
-    override func getJSONValues() -> [String: Any] {
+    func getJSONValues() -> [String: Any] {
         let pokemonStats = try? Stats.getPokemonStats()
         let pokemonIVStats = try? Stats.getPokemonIVStats()
         let raidStats = try? Stats.getRaidStats()

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -121,17 +121,17 @@ class Stats {
         if Stats.pokemonCountStats && old == nil || old!.cp != new.cp {
             // pokemon is new or cp has changed (eg encountered, or re-encountered)
             pokemonStatsLock.lock()
-
+            let pokemonId = new.pokemonId.toInt()
             if old == nil || old!.pokemonId != new.pokemonId { // pokemon is new or type has changed
-                pokemonCount.count[new.pokemonId] += 1
+                pokemonCount.count[pokemonId] += 1
             }
             if new.cp != nil {
-                pokemonCount.ivCount[new.pokemonId] += 1
+                pokemonCount.ivCount[pokemonId] += 1
                 if let shiny = new.shiny, shiny == true {
-                    pokemonCount.shiny[new.pokemonId] += 1
+                    pokemonCount.shiny[pokemonId] += 1
                 }
                 if let atk = new.atkIv, atk == 15, let def = new.defIv, def == 15, let sta = new.staIv, sta == 15 {
-                    pokemonCount.hundos[new.pokemonId] += 1
+                    pokemonCount.hundos[pokemonId] += 1
                 }
             }
             pokemonStatsLock.unlock()

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -45,7 +45,7 @@ class Stats {
 
         if Stats.pokemonCountStats {
             Log.info(message: "[STATS] Enabled pokemon count for stats")
-            startStatsLogger()
+            startPokemonCountStatsLogger()
         } else {
             Log.info(message: "[STATS] Disabled pokemon count for stats")
         }
@@ -104,7 +104,7 @@ class Stats {
         }
     }
 
-    private func startStatsLogger() {
+    private func startPokemonCountStatsLogger() {
         Threading.getQueue(name: "StatsLogger", type: .serial).dispatch {
             while true {
                 Threading.sleep(seconds: 600)
@@ -115,6 +115,10 @@ class Stats {
                 self.logPokemonCount(mysql: mysql)
             }
         }
+    }
+
+    public func updatePokemonCountStats(old: Pokemon?, new: Pokemon) {
+
     }
 
     // =================================================================================================================

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -72,7 +72,7 @@ class Stats: JSONConvertibleObject {
                 }
                 let start = Date()
                 let affectedRows: UInt?
-                if pokemonArchiveEnabled {
+                if Stats.pokemonArchiveEnabled {
                     affectedRows = self.createStatsAndArchive(mysql: mysql)
                 } else {
                     affectedRows = self.clearPokemon(mysql: mysql, keepTime: keepTime, batchSize: batchSize)
@@ -273,10 +273,10 @@ class Stats: JSONConvertibleObject {
         var ivCount: [Int]
 
         init() {
-            hundos = [Int](repeating: 0, count: maxPokemon)
-            shiny = [Int](repeating: 0, count: maxPokemon)
-            count = [Int](repeating: 0, count: maxPokemon)
-            ivCount = [Int](repeating: 0, count: maxPokemon)
+            hundos = [Int](repeating: 0, count: Stats.maxPokemon)
+            shiny = [Int](repeating: 0, count: Stats.maxPokemon)
+            count = [Int](repeating: 0, count: Stats.maxPokemon)
+            ivCount = [Int](repeating: 0, count: Stats.maxPokemon)
         }
     }
 

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -118,7 +118,23 @@ class Stats {
     }
 
     public func updatePokemonCountStats(old: Pokemon?, new: Pokemon) {
+        if old == nil || old!.cp != new.cp { // pokemon is new or cp has changed (eg encountered, or re-encountered)
+            pokemonStatsLock.lock()
 
+            if old == nil || old!.pokemonId != new.pokemonId { // pokemon is new or type has changed
+                pokemonCount.count[new.pokemonId]++
+            }
+            if new.cp != nil {
+                pokemonCount.ivCount[new.pokemonId]++
+                if new.shiny {
+                    pokemonCount.shiny[new.pokemonId]++
+                }
+                if let atk = new.atkIv, atk == 15, let def = new.defIv, def == 15, let sta = new.staIv, sta == 15 {
+                    pokemonCount.hundos[new.pokemonId]++
+                }
+            }
+            pokemonStatsLock.unlock()
+        }
     }
 
     // =================================================================================================================

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -123,15 +123,15 @@ class Stats {
             pokemonStatsLock.lock()
 
             if old == nil || old!.pokemonId != new.pokemonId { // pokemon is new or type has changed
-                pokemonCount.count[new.pokemonId]++
+                pokemonCount.count[new.pokemonId] =+ 1
             }
             if new.cp != nil {
-                pokemonCount.ivCount[new.pokemonId]++
+                pokemonCount.ivCount[new.pokemonId] =+ 1
                 if new.shiny {
-                    pokemonCount.shiny[new.pokemonId]++
+                    pokemonCount.shiny[new.pokemonId] =+ 1
                 }
                 if let atk = new.atkIv, atk == 15, let def = new.defIv, def == 15, let sta = new.staIv, sta == 15 {
-                    pokemonCount.hundos[new.pokemonId]++
+                    pokemonCount.hundos[new.pokemonId] =+ 1
                 }
             }
             pokemonStatsLock.unlock()

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -127,7 +127,7 @@ class Stats {
             }
             if new.cp != nil {
                 pokemonCount.ivCount[new.pokemonId] =+ 1
-                if new.shiny {
+                if let shiny = new.shiny, shiny == true {
                     pokemonCount.shiny[new.pokemonId] =+ 1
                 }
                 if let atk = new.atkIv, atk == 15, let def = new.defIv, def == 15, let sta = new.staIv, sta == 15 {

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -118,7 +118,8 @@ class Stats {
     }
 
     public func updatePokemonCountStats(old: Pokemon?, new: Pokemon) {
-        if Stats.pokemonCountStats && old == nil || old!.cp != new.cp { // pokemon is new or cp has changed (eg encountered, or re-encountered)
+        if Stats.pokemonCountStats && old == nil || old!.cp != new.cp {
+            // pokemon is new or cp has changed (eg encountered, or re-encountered)
             pokemonStatsLock.lock()
 
             if old == nil || old!.pokemonId != new.pokemonId { // pokemon is new or type has changed

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -16,13 +16,14 @@ class Stats: JSONConvertibleObject {
 
     public static let global = Stats()
 
+    public static var pokemonCountStats = true
     public static var pokemonArchiveEnabled = false
     public static var cleanupPokemon = true
     public static var cleanupIncident = true
 
     private static var maxPokemon = 1000
-    private static var pokemonStatsLock = Threading.Lock()
-    private static var pokemonCount = PokemonCountDetail()
+    private var pokemonStatsLock = Threading.Lock()
+    private var pokemonCount = PokemonCountDetail()
 
     private init() {
         if Stats.cleanupPokemon {
@@ -31,15 +32,22 @@ class Stats: JSONConvertibleObject {
             } else {
                 Log.info(message: "[STATS] Cleanup of Pokemon enabled, pokemon history for stats disabled")
             }
-            Stats.startDatabaseArchiver()
+            startDatabaseArchiver()
         } else {
             Log.info(message: "[STATS] Cleanup and pokemon history for pokemon disabled")
         }
         if Stats.cleanupIncident {
             Log.info(message: "[STATS] Cleanup of incidents enabled")
-            Stats.startIncidentExpiry()
+            startIncidentExpiry()
         } else {
             Log.info(message: "[STATS] Cleanup of incidents disabled")
+        }
+
+        if Stats.pokemonCountStats {
+            Log.info(message: "[STATS] Enabled pokemon count for stats")
+            startStatsLogger()
+        } else {
+            Log.info(message: "[STATS] Disabled pokemon count for stats")
         }
     }
 

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -73,9 +73,9 @@ class Stats: JSONConvertibleObject {
                 let start = Date()
                 let affectedRows: UInt?
                 if pokemonArchiveEnabled {
-                    affectedRows = createStatsAndArchive(mysql: mysql)
+                    affectedRows = self.createStatsAndArchive(mysql: mysql)
                 } else {
-                    affectedRows = clearPokemon(mysql: mysql, keepTime: keepTime, batchSize: batchSize)
+                    affectedRows = self.clearPokemon(mysql: mysql, keepTime: keepTime, batchSize: batchSize)
                 }
                 Log.info(message: "[STATS] [DatabaseArchiver] Archive of pokemon table took " +
                     "\(String(format: "%.3f", Date().timeIntervalSince(start)))s " +
@@ -97,7 +97,7 @@ class Stats: JSONConvertibleObject {
                     continue
                 }
                 let start = Date()
-                let affectedRows = clearIncident(mysql: mysql, keepTime: keepTime, batchSize: batchSize)
+                let affectedRows = self.clearIncident(mysql: mysql, keepTime: keepTime, batchSize: batchSize)
                 Log.info(message: "[STATS] [IncidentExpiry] Cleanup of incident table took " +
                     "\(String(format: "%.3f", Date().timeIntervalSince(start)))s (\(affectedRows) rows)")
             }
@@ -112,7 +112,7 @@ class Stats: JSONConvertibleObject {
                     Log.error(message: "[STATS] [StatsLogger] Failed to connect to database.")
                     continue
                 }
-                logPokemonCount(mysql: mysql)
+                self.logPokemonCount(mysql: mysql)
             }
         }
     }

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -231,7 +231,7 @@ class Stats: JSONConvertibleObject {
     }
 
     private func updateStatsCount(mysql: MySQL, table: String, rows: [PokemonCountDbRow]) {
-        //TODO: join rows to a mult insert statement
+        //MARK: join rows to a mult insert statement
     }
 
     struct PokemonCountDetail {

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -233,8 +233,6 @@ class Stats {
         formatter.timeZone = Localizer.global.timeZone
         let midnight = formatter.string(from: Date())
 
-        print("[TMP] \(midnight)")
-
         for (pokemonId, count) in currentStats.count.enumerated() where count > 0 {
             allRows.append(PokemonCountDbRow(date: midnight, pokemonId: pokemonId, count: count))
         }

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -194,10 +194,11 @@ class Stats: JSONConvertibleObject {
     }
 
     private func logPokemonCount(mysql: MySQL) {
-        pokemonStatsLock.lock()
-        let currentStats = pokemonCount
-        pokemonCount = PokemonCountDetail()
-        pokemonStatsLock.unlock()
+        var currentStats = PokemonCountDetail()
+        pokemonStatsLock.doWithLock {
+            currentStats = self.pokemonCount
+            pokemonCount = PokemonCountDetail()
+        }
 
         var hundoRows = [PokemonCountDbRow]()
         var shinyRows = [PokemonCountDbRow]()
@@ -206,7 +207,10 @@ class Stats: JSONConvertibleObject {
 
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = Localizer.global.timeZone
         let midnight = formatter.string(from: Date())
+
+        print("[TMP] \(midnight)")
 
         for (pokemonId, count) in currentStats.count.enumerated() where count > 0 {
             allRows.append(PokemonCountDbRow(date: midnight, pokemonId: pokemonId, count: count))
@@ -231,7 +235,7 @@ class Stats: JSONConvertibleObject {
     }
 
     private func updateStatsCount(mysql: MySQL, table: String, rows: [PokemonCountDbRow]) {
-        //MARK: join rows to a mult insert statement
+        // MARK: join rows to a mult insert statement
     }
 
     struct PokemonCountDetail {

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -118,7 +118,7 @@ class Stats {
     }
 
     public func updatePokemonCountStats(old: Pokemon?, new: Pokemon) {
-        if old == nil || old!.cp != new.cp { // pokemon is new or cp has changed (eg encountered, or re-encountered)
+        if Stats.pokemonCountStats && old == nil || old!.cp != new.cp { // pokemon is new or cp has changed (eg encountered, or re-encountered)
             pokemonStatsLock.lock()
 
             if old == nil || old!.pokemonId != new.pokemonId { // pokemon is new or type has changed

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -179,29 +179,21 @@ class Stats: JSONConvertibleObject {
         formatter.dateFormat = "yyyy-MM-dd"
         let midnight = formatter.string(from: Date())
 
-        for (pokemonId, count) in currentStats.count.enumerated() {
-            if count > 0 {
-                let row = PokemonCountDbRow(date: midnight, pokemonId: pokemonId, count: count)
-                allRows.append(row)
-            }
+        for (pokemonId, count) in currentStats.count.enumerated() where count > 0 {
+            allRows.append(PokemonCountDbRow(date: midnight, pokemonId: pokemonId, count: count))
         }
 
-        for (pokemonId, count) in currentStats.ivCount.enumerated() {
-            if count > 0 {
-                ivRows.append(PokemonCountDbRow(date: midnight, pokemonId: pokemonId, count: count))
-            }
+        for (pokemonId, count) in currentStats.ivCount.enumerated() where count > 0 {
+            ivRows.append(PokemonCountDbRow(date: midnight, pokemonId: pokemonId, count: count))
+
         }
 
-        for (pokemonId, count) in currentStats.hundos.enumerated() {
-            if count > 0 {
-                hundoRows.append(PokemonCountDbRow(date: midnight, pokemonId: pokemonId, count: count))
-            }
+        for (pokemonId, count) in currentStats.hundos.enumerated() where count > 0 {
+            hundoRows.append(PokemonCountDbRow(date: midnight, pokemonId: pokemonId, count: count))
         }
 
-        for (pokemonId, count) in currentStats.shiny.enumerated() {
-            if count > 0 {
-                shinyRows.append(PokemonCountDbRow(date: midnight, pokemonId: pokemonId, count: count))
-            }
+        for (pokemonId, count) in currentStats.shiny.enumerated() where count > 0 {
+            shinyRows.append(PokemonCountDbRow(date: midnight, pokemonId: pokemonId, count: count))
         }
 
         updateStatsCount(mysql: mysql, table: "pokemon_stats", rows: allRows)

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -123,15 +123,15 @@ class Stats {
             pokemonStatsLock.lock()
 
             if old == nil || old!.pokemonId != new.pokemonId { // pokemon is new or type has changed
-                pokemonCount.count[new.pokemonId] =+ 1
+                pokemonCount.count[new.pokemonId] += 1
             }
             if new.cp != nil {
-                pokemonCount.ivCount[new.pokemonId] =+ 1
+                pokemonCount.ivCount[new.pokemonId] += 1
                 if let shiny = new.shiny, shiny == true {
-                    pokemonCount.shiny[new.pokemonId] =+ 1
+                    pokemonCount.shiny[new.pokemonId] += 1
                 }
                 if let atk = new.atkIv, atk == 15, let def = new.defIv, def == 15, let sta = new.staIv, sta == 15 {
-                    pokemonCount.hundos[new.pokemonId] =+ 1
+                    pokemonCount.hundos[new.pokemonId] += 1
                 }
             }
             pokemonStatsLock.unlock()

--- a/Sources/RealDeviceMapLib/Modell/Stats.swift
+++ b/Sources/RealDeviceMapLib/Modell/Stats.swift
@@ -244,10 +244,10 @@ class Stats: JSONConvertibleObject {
         for _ in 1..<rows.count {
             values += "(?,?,?), "
         }
-        values += "(?,?,?)"
+        values += "(?,?,?) "
 
         var sql = """
-                  INSERT INTO \(table) (date, pokemon_id, `count`) VALUES \(values) 
+                  INSERT INTO \(table) (date, pokemon_id, `count`) VALUES \(values)
                   ON DUPLICATE KEY UPDATE `count` = `count` + VALUES(`count`)
                   """
 

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -217,7 +217,7 @@ public func setupRealDeviceMap() {
     Pokemon.weatherIVClearingEnabled = ConfigLoader.global.getConfig(type: .ivWeatherClearing)
     Pokemon.cellPokemonEnabled = ConfigLoader.global.getConfig(type: .saveCellPokemon)
     Pokemon.saveSpawnpointLastSeen = ConfigLoader.global.getConfig(type: .saveSpawnPointLastSeen)
-    Pokemon.statsEnabled = ConfigLoader.global.getConfig(type: .statsEnabled)
+    Pokemon.timingStatsEnabled = ConfigLoader.global.getConfig(type: .statsEnabled)
     InstanceController.requireAccountEnabled = ConfigLoader.global.getConfig(type: .accRequiredInDB)
     InstanceController.sendTaskForLureEncounter = ConfigLoader.global.getConfig(type: .scanLureEncounter)
 
@@ -312,26 +312,10 @@ public func setupRealDeviceMap() {
     }
 
     // Config for history stats and cleanup
-    Stats.statsEnabled = ConfigLoader.global.getConfig(type: .statsEnabled)
+    Stats.pokemonArchiveEnabled = ConfigLoader.global.getConfig(type: .statsEnabled)
     Stats.cleanupPokemon = ConfigLoader.global.getConfig(type: .dbClearerPokemonEnabled)
     Stats.cleanupIncident = ConfigLoader.global.getConfig(type: .dbClearerIncidentEnabled)
-
-    if Stats.cleanupPokemon {
-        if Stats.statsEnabled {
-            Log.info(message: "[MAIN] [STATS] Enabled pokemon history for stats")
-        } else {
-            Log.info(message: "[MAIN] [STATS] Cleanup of Pokemon enabled, pokemon history for stats disabled")
-        }
-        Stats.startDatabaseArchiver()
-    } else {
-        Log.info(message: "[MAIN] [STATS] Cleanup and pokemon history for pokemon disabled")
-    }
-    if Stats.cleanupIncident {
-        Log.info(message: "[MAIN] [STATS] Cleanup of incidents enabled")
-        Stats.startIncidentExpiry()
-    } else {
-        Log.info(message: "[MAIN] [STATS] Cleanup of incidents disabled")
-    }
+    _ = Stats.global
 
     // Check if is setup
     Log.info(message: "[MAIN] Checking if setup is completed")

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -217,7 +217,7 @@ public func setupRealDeviceMap() {
     Pokemon.weatherIVClearingEnabled = ConfigLoader.global.getConfig(type: .ivWeatherClearing)
     Pokemon.cellPokemonEnabled = ConfigLoader.global.getConfig(type: .saveCellPokemon)
     Pokemon.saveSpawnpointLastSeen = ConfigLoader.global.getConfig(type: .saveSpawnPointLastSeen)
-    Pokemon.timingStatsEnabled = ConfigLoader.global.getConfig(type: .statsEnabled)
+    Pokemon.timingStatsEnabled = ConfigLoader.global.getConfig(type: .statsPokemonTimingEnabled)
     InstanceController.requireAccountEnabled = ConfigLoader.global.getConfig(type: .accRequiredInDB)
     InstanceController.sendTaskForLureEncounter = ConfigLoader.global.getConfig(type: .scanLureEncounter)
 
@@ -312,7 +312,8 @@ public func setupRealDeviceMap() {
     }
 
     // Config for history stats and cleanup
-    Stats.pokemonArchiveEnabled = ConfigLoader.global.getConfig(type: .statsEnabled)
+    Stats.pokemonArchiveEnabled = ConfigLoader.global.getConfig(type: .statsPokemonArchiveEnabled)
+    Stats.pokemonCountStats = ConfigLoader.global.getConfig(type: .statsPokemonCountEnabled)
     Stats.cleanupPokemon = ConfigLoader.global.getConfig(type: .dbClearerPokemonEnabled)
     Stats.cleanupIncident = ConfigLoader.global.getConfig(type: .dbClearerIncidentEnabled)
     _ = Stats.global

--- a/resources/config/default.json
+++ b/resources/config/default.json
@@ -76,7 +76,13 @@
         "batchSize": 250
       }
     },
-    "stats": false,
+    "stats": {
+      "pokemon": {
+        "archive": false,
+        "timing": false,
+        "count": true
+      }
+    },
     "pvp": {
       "enabled": true,
       "levelCaps": [50],

--- a/resources/config/local.example.json
+++ b/resources/config/local.example.json
@@ -42,7 +42,13 @@
         "enabled": true
       }
     },
-    "stats": false,
+    "stats": {
+      "pokemon": {
+        "archive": false,
+        "timing": false,
+        "count": true
+      }
+    },
     "pvp": {
       "enabled": true,
       "levelCaps": [50],

--- a/resources/migrations/96.sql
+++ b/resources/migrations/96.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS pokemon_updated;
+DROP TRIGGER IF EXISTS pokemon_inserted;


### PR DESCRIPTION
- Remove DB triggers `pokemon_inserted` & `pokemon_updated`
- Count stats are updated now in memory
- Count stats are written to DB every 10 minutes (if you restart during that timeframe it will loose some data, because updated in memory)
- :warning: new config options, removed old ones :warning: 
- if you enabled `stats: true` for "pokemon_history", then pls check new config options

```json
    "stats": {
      "pokemon": {
        "archive": false, // in combination with clearer.pokemon.enabled = true it will clear and archive pokemon in pokemon_history table
        "timing": false, // used to create timing stats for dkmur/rdmStats 
        "count": true // represents all the pokemon count stats, like pokemon_stats, pokemon_hundo, pokemon_iv, pokemon_shiny
      }
    },
```

closes #439 