### PR TITLE
Clear Quests on midnight improved

### DIFF
--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -10,6 +10,7 @@
 import Foundation
 import PerfectLib
 import PerfectMySQL
+import PerfectThread
 import POGOProtos
 
 public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable {
@@ -1103,6 +1104,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
         }
 
         for chunks in ids!.chunked(into: 1000) {
+            Threading.sleep(seconds: 0.2)
             var inSQL = "("
             for _ in 1..<chunks.count {
                 inSQL += "?, "

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -1101,7 +1101,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
             Log.error(message: "[POKESTOP] Failed to connect to database.")
             throw DBController.DBError()
         }
-        var errorOccurredOnSomeChunks = false
+
         for chunks in ids!.chunked(into: 1000) {
             var inSQL = "("
             for _ in 1..<chunks.count {
@@ -1109,7 +1109,6 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
             }
             inSQL += "?)"
             let whereSQL = "WHERE id IN \(inSQL)"
-
 
             let sql = """
                           UPDATE pokestop
@@ -1131,11 +1130,8 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
 
             guard mysqlStmt.execute() else {
                 Log.error(message: "[POKESTOP] Failed to execute query 'clearQuests'. (\(mysqlStmt.errorMessage())")
-                errorOccurredOnSomeChunks = true
+                throw DBController.DBError()
             }
-        }
-        if errorOccurredOnSomeChunks {
-            throw DBController.DBError()
         }
 
         Pokestop.cache?.clear()

--- a/Sources/RealDeviceMapLib/Modell/Pokestop.swift
+++ b/Sources/RealDeviceMapLib/Modell/Pokestop.swift
@@ -1093,7 +1093,7 @@ public class Pokestop: JSONConvertibleObject, NSCopying, WebHookEvent, Hashable 
 
     public static func clearQuests(mysql: MySQL?=nil, ids: [String]?=nil) throws {
 
-        if ids?.count == 0 {
+        if ids == nil || ids!.count == 0 {
             return
         }
 


### PR DESCRIPTION
It seems that for clearing quests at midnight we clear thousands of rows at same time, because we delete for IDs. I introduced chunks of 1000 to clear now.