### PR TITLE
Update spins of account on leveling instance

### DIFF
--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/LevelingInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/LevelingInstanceController.swift
@@ -144,6 +144,7 @@ class LevelingInstanceController: InstanceControllerProto {
         }
 
         do {
+            try Account.spin(mysql: mysql, username: username)
             try Cooldown.encounter(
                 mysql: mysql,
                 account: account,


### PR DESCRIPTION
implements #469 
as there is no spins left check in leveling it's quite useless to increase it. there was a check in the past, but it was removed?! anybody know why?!