### PR TITLE
Sync Development -> Master

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
+++ b/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
@@ -23,7 +23,7 @@ public class ConfigLoader {
         "USE_RW_FOR_QUEST", "USE_RW_FOR_RAID", "NO_GENERATE_IMAGES", "NO_PVP", "NO_IV_WEATHER_CLEARING",
         "NO_CELL_POKEMON", "SAVE_SPAWNPOINT_LASTSEEN", "NO_MEMORY_CACHE", "NO_BACKUP", "NO_REQUIRE_ACCOUNT",
         "SCAN_LURE_ENCOUNTER", "QUEST_RETRY_LIMIT", "SPIN_DISTANCE", "ALLOW_AR_QUESTS", "STOP_ALL_BOOTSTRAPPING",
-        "USE_RW_FOR_POKES", "NO_DB_CLEARER", "NO_DB_CLEARER_INCIDENT"
+        "USE_RW_FOR_POKES", "NO_DB_CLEARER", "NO_DB_CLEARER_INCIDENT", "ACC_MAX_ENCOUNTERS", "ACC_DISABLE_PERIOD"
     ]
 
     private init() {
@@ -88,6 +88,10 @@ public class ConfigLoader {
             ?? defaultConfig.application.account.useRwForQuest.value()!
         case .accUseRwForRaid: return localConfig.application.account.useRwForRaid.value()
             ?? defaultConfig.application.account.useRwForRaid.value()!
+        case .accMaxEncounters: return localConfig.application.account.maxEncounters.value()
+            ?? defaultConfig.application.account.maxEncounters.value()!
+        case .accDisablePeriod: return localConfig.application.account.disablePeriod.value()
+            ?? defaultConfig.application.account.disablePeriod.value()!
         case .loginLimit: return localConfig.application.loginLimit.enabled.value()
             ?? defaultConfig.application.loginLimit.enabled.value()!
         case .loginLimitCount: return localConfig.application.loginLimit.count.value()
@@ -183,6 +187,8 @@ public class ConfigLoader {
         case .accRequiredInDB: return false as! T // NO_REQUIRE_ACCOUNT
         case .accUseRwForQuest: return false as! T // USE_RW_FOR_QUEST
         case .accUseRwForRaid: return false as! T // USE_RW_FOR_RAID
+        case .accMaxEncounters: return castValue(value: value)
+        case .accDisablePeriod: return castValue(value: value)
         case .loginLimit: return false as! T
         case .loginLimitCount: return castValue(value: value)
         case .loginLimitInterval: return castValue(value: value)
@@ -259,6 +265,8 @@ public class ConfigLoader {
         case accRequiredInDB = "NO_REQUIRE_ACCOUNT"
         case accUseRwForQuest = "USE_RW_FOR_QUEST"
         case accUseRwForRaid = "USE_RW_FOR_RAID"
+        case accMaxEncounters = "ACC_MAX_ENCOUNTERS"
+        case accDisablePeriod = "ACC_DISABLE_PERIOD"
         case loginLimit = "LOGIN_LIMIT" // not used in env
         case loginLimitCount = "LOGINLIMIT_COUNT"
         case loginLimitInterval = "LOGINLIMIT_INTERVALL"

--- a/Sources/RealDeviceMapLib/Modell/Account.swift
+++ b/Sources/RealDeviceMapLib/Modell/Account.swift
@@ -20,7 +20,7 @@ public class Account: WebHookEvent {
 
     static let suspendedPeriod: UInt32 = 2592000
     static let warnedPeriod: UInt32 = 604800
-    static let unknownPeriod: UInt32 = 86400 // mostly blue maintenance mode screen
+    static var disablePeriod: UInt32 = (ConfigLoader.global.getConfig(type: .accDisablePeriod) as Int).toUInt32()
 
     func getWebhookValues(type: String) -> [String: Any] {
 
@@ -39,6 +39,8 @@ public class Account: WebHookEvent {
             "suspended_message_acknowledged": suspendedMessageAcknowledged ?? 0,
             "was_suspended": wasSuspended ?? 0,
             "banned": banned ?? 0,
+            "disabled": disabled,
+            "last_disabled": lastDisabled ?? 0,
             "group": group as Any
         ]
         return [
@@ -65,13 +67,25 @@ public class Account: WebHookEvent {
     var wasSuspended: Bool?
     var banned: Bool?
     var lastUsedTimestamp: UInt32?
+    var disabled: Bool
+    var lastDisabled: UInt32?
     var group: String?
+
+    init(username: String, password: String, level: UInt8, spins: UInt16, disabled: Bool, group: String?) {
+        self.username = username
+        self.password = password
+        self.level = level
+        self.spins = spins
+        self.disabled = disabled
+        self.group = group?.emptyToNil()
+    }
 
     init(username: String, password: String, level: UInt8, firstWarningTimestamp: UInt32?,
          failedTimestamp: UInt32?, failed: String?, lastEncounterLat: Double?, lastEncounterLon: Double?,
          lastEncounterTime: UInt32?, spins: UInt16, creationTimestamp: UInt32?, warn: Bool?,
          warnExpireTimestamp: UInt32?, warnMessageAcknowledged: Bool?, suspendedMessageAcknowledged: Bool?,
-         wasSuspended: Bool?, banned: Bool?, lastUsedTimestamp: UInt32?, group: String?) {
+         wasSuspended: Bool?, banned: Bool?, lastUsedTimestamp: UInt32?, disabled: Bool, lastDisabled: UInt32?,
+         group: String?) {
         self.username = username
         self.password = password
         self.level = level
@@ -96,6 +110,8 @@ public class Account: WebHookEvent {
         self.wasSuspended = wasSuspended
         self.banned = banned
         self.lastUsedTimestamp = lastUsedTimestamp
+        self.disabled = disabled
+        self.lastDisabled = lastDisabled
         self.group = group?.emptyToNil()
     }
 
@@ -164,9 +180,9 @@ public class Account: WebHookEvent {
                     username, password, level, first_warning_timestamp, failed_timestamp, failed, last_encounter_lat,
                     last_encounter_lon, last_encounter_time, spins, creation_timestamp, warn, warn_expire_timestamp,
                     warn_message_acknowledged, suspended_message_acknowledged, was_suspended, banned,
-                    last_used_timestamp, `group`
+                    last_used_timestamp, disabled, last_disabled, `group`
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """
             _ = mysqlStmt.prepare(statement: sql)
 
@@ -218,6 +234,9 @@ public class Account: WebHookEvent {
             if lastUsedTimestamp == nil && oldAccount!.lastUsedTimestamp != nil {
                 self.lastUsedTimestamp = oldAccount!.lastUsedTimestamp!
             }
+            if lastDisabled == nil && oldAccount!.lastDisabled != nil {
+                self.lastDisabled = oldAccount!.lastDisabled
+            }
 
             let sql = """
                 UPDATE account
@@ -225,7 +244,7 @@ public class Account: WebHookEvent {
                     last_encounter_lat = ?, last_encounter_lon = ?, last_encounter_time = ?, spins = ?,
                     creation_timestamp = ?, warn = ?, warn_expire_timestamp = ?, warn_message_acknowledged = ?,
                     suspended_message_acknowledged = ?, was_suspended = ?, banned = ?, last_used_timestamp = ?,
-                    `group` = ?
+                    disabled = ?, last_disabled = ?, `group` = ?
                 WHERE username = ?
             """
             _ = mysqlStmt.prepare(statement: sql)
@@ -250,6 +269,8 @@ public class Account: WebHookEvent {
         mysqlStmt.bindParam(wasSuspended)
         mysqlStmt.bindParam(banned)
         mysqlStmt.bindParam(lastUsedTimestamp)
+        mysqlStmt.bindParam(disabled)
+        mysqlStmt.bindParam(lastDisabled)
         mysqlStmt.bindParam(group)
 
         if oldAccount != nil {
@@ -264,24 +285,54 @@ public class Account: WebHookEvent {
         if oldAccount == nil {
             WebHookController.global.addAccountEvent(account: self)
         } else if self.level != oldAccount!.level || self.failed != oldAccount!.failed ||
-                  self.warn != oldAccount!.warn || self.banned != oldAccount!.banned {
+                  self.warn != oldAccount!.warn || self.banned != oldAccount!.banned ||
+                  self.disabled != oldAccount!.disabled {
             WebHookController.global.addAccountEvent(account: self)
         }
+    }
+
+    public static func insertAccountBatch(mysql: MySQL?=nil, accounts: [Account]) throws {
+        guard let mysql = mysql ?? DBController.global.mysql else {
+            Log.error(message: "[ACCOUNT] Failed to connect to database.")
+            throw DBController.DBError()
+        }
+        for chunks in accounts.chunked(into: 200) {
+            let placeholders = [String].init(repeating: "(?,?,?,?,?,?)", count: chunks.count).joined(separator: ", ")
+            let sql =
+                """
+                  INSERT IGNORE INTO account (username, password, level, spins, disabled, `group`)
+                  VALUES \(placeholders)
+                """
+            let mysqlStmt = MySQLStmt(mysql)
+            _ = mysqlStmt.prepare(statement: sql)
+            for account in chunks {
+                mysqlStmt.bindParam(account.username)
+                mysqlStmt.bindParam(account.password)
+                mysqlStmt.bindParam(account.level)
+                mysqlStmt.bindParam(account.spins)
+                mysqlStmt.bindParam(account.disabled)
+                mysqlStmt.bindParam(account.group)
+            }
+            guard mysqlStmt.execute() else {
+                Log.error(message: "[ACCOUNT] Failed to execute query 'insertAccountBatch'. " +
+                    mysqlStmt.errorMessage())
+                throw DBController.DBError()
+            }
+        }
+        Log.info(message: "[ACCOUNT] Added \(accounts.count) new accounts into database.")
     }
 
     public func isValid(ignoringWarning: Bool=false, group: String?=nil) -> Bool {
         let now = UInt32(Date().timeIntervalSince1970)
         return (
             self.group == group &&
+                (!self.disabled || (self.disabled && (self.lastDisabled ?? 0) <= now - Account.disablePeriod)) &&
             (self.failed == nil || (
                 self.failed! == "GPR_RED_WARNING" &&
                 (ignoringWarning || (self.warnExpireTimestamp ?? UInt32.max) <= now)
             ) || (
                 self.failed! == "suspended" &&
                 ((self.failedTimestamp ?? UInt32.max) <= now - Account.suspendedPeriod)
-            ) || (
-                self.failed! == "unknown" &&
-                    ((self.failedTimestamp ?? UInt32.max) <= now - Account.unknownPeriod)
             ))
         )
     }
@@ -411,6 +462,29 @@ public class Account: WebHookEvent {
         }
     }
 
+    public static func setDisabled(mysql: MySQL?=nil, username: String, disabled: Bool = true) throws {
+
+        guard let mysql = mysql ?? DBController.global.mysql else {
+            Log.error(message: "[ACCOUNT] Failed to connect to database.")
+            throw DBController.DBError()
+        }
+
+        let mysqlStmt = MySQLStmt(mysql)
+        let sql = """
+                      UPDATE account
+                      SET disabled = ? \(disabled ? ", last_disabled = UNIX_TIMESTAMP()" : "")
+                      WHERE username = ?
+                  """
+        _ = mysqlStmt.prepare(statement: sql)
+        mysqlStmt.bindParam(disabled)
+        mysqlStmt.bindParam(username)
+
+        guard mysqlStmt.execute() else {
+            Log.error(message: "[ACCOUNT] Failed to execute query 'setDisabled'. (\(mysqlStmt.errorMessage())")
+            throw DBController.DBError()
+        }
+    }
+
     public static func getNewAccount(mysql: MySQL?=nil, minLevel: UInt8, maxLevel: UInt8,
                                      ignoringWarning: Bool=false, spins: Int?=1000,
                                      noCooldown: Bool=true, encounterTarget: Coord?=nil,
@@ -434,8 +508,7 @@ public class Account: WebHookEvent {
                 (failed IS NULL AND first_warning_timestamp IS NULL) OR
                 (failed = 'GPR_RED_WARNING' AND warn_expire_timestamp IS NOT NULL AND
                  warn_expire_timestamp != 0 AND warn_expire_timestamp <= UNIX_TIMESTAMP()) OR
-                (failed = 'suspended' AND failed_timestamp <= UNIX_TIMESTAMP() - \(Account.suspendedPeriod)) OR
-                (failed = 'unknown' AND failed_timestamp <= UNIX_TIMESTAMP() - \(Account.unknownPeriod))
+                (failed = 'suspended' AND failed_timestamp <= UNIX_TIMESTAMP() - \(Account.suspendedPeriod))
             )
             """
         }
@@ -506,14 +579,15 @@ public class Account: WebHookEvent {
             SELECT username, password, level, first_warning_timestamp, failed_timestamp, failed, last_encounter_lat,
                 last_encounter_lon, last_encounter_time, spins, creation_timestamp, warn, warn_expire_timestamp,
                 warn_message_acknowledged, suspended_message_acknowledged, was_suspended, banned, last_used_timestamp,
-                `group`
+                disabled, last_disabled, `group`
             FROM account
             LEFT JOIN device ON username = account_username
             WHERE
                 device.uuid IS NULL AND
                 `group` \(group != nil ? "= ?" : "IS NULL") AND
                 level >= ? AND
-                level <= ?
+                level <= ? AND
+                (disabled = 0 OR (disabled = 1 AND last_disabled <= UNIX_TIMESTAMP() - \(Account.disablePeriod)))
                 \(failedSQL)
                 \(spinSQL)
                 \(cooldownSQL)
@@ -571,7 +645,9 @@ public class Account: WebHookEvent {
         let wasSuspended = result[15] as? Bool
         let banned = result[16] as? Bool
         let lastUsedTimestamp = result[17] as? UInt32
-        let group = (result[18] as? String)?.emptyToNil()
+        let disabled = (result[18] as? UInt8)!.toBool()
+        let lastDisabled = result[19] as? UInt32
+        let group = (result[20] as? String)?.emptyToNil()
 
         Account.lockoutLock.doWithLock {
             Account.lockouts.append((account: username, device: device, untill: now.addingTimeInterval(300)))
@@ -579,6 +655,9 @@ public class Account: WebHookEvent {
         Account.lockoutLock.unlock()
 
         try? Account.setLastUsed(mysql: mysql, username: username)
+        if disabled {
+            try? Account.setDisabled(mysql: mysql, username: username, disabled: false)
+        }
         return Account(
             username: username, password: password, level: level, firstWarningTimestamp: firstWarningTimestamp,
             failedTimestamp: failedTimestamp, failed: failed, lastEncounterLat: lastEncounterLat,
@@ -586,7 +665,7 @@ public class Account: WebHookEvent {
             creationTimestamp: creationTimestamp, warn: warn, warnExpireTimestamp: warnExpireTimestamp,
             warnMessageAcknowledged: warnMessageAcknowledged,
             suspendedMessageAcknowledged: suspendedMessageAcknowledged, wasSuspended: wasSuspended, banned: banned,
-            lastUsedTimestamp: lastUsedTimestamp, group: group)
+            lastUsedTimestamp: lastUsedTimestamp, disabled: disabled, lastDisabled: lastDisabled, group: group)
     }
 
     public static func getWithUsername(mysql: MySQL?=nil, username: String) throws -> Account? {
@@ -600,7 +679,7 @@ public class Account: WebHookEvent {
             SELECT username, password, level, first_warning_timestamp, failed_timestamp, failed,
                    last_encounter_lat, last_encounter_lon, last_encounter_time, spins, creation_timestamp,
                    warn, warn_expire_timestamp, warn_message_acknowledged, suspended_message_acknowledged,
-                  was_suspended, banned, last_used_timestamp, `group`
+                  was_suspended, banned, last_used_timestamp, disabled, last_disabled, `group`
             FROM account
             WHERE username = ?
         """
@@ -638,7 +717,9 @@ public class Account: WebHookEvent {
         let wasSuspended = result[15] as? Bool
         let banned = result[16] as? Bool
         let lastUsedTimestamp = result[17] as? UInt32
-        let group = (result[18] as? String)?.emptyToNil()
+        let disabled = (result[18] as? UInt8)!.toBool()
+        let lastDisabled = result[19] as? UInt32
+        let group = (result[20] as? String)?.emptyToNil()
 
         return Account(
             username: username, password: password, level: level, firstWarningTimestamp: firstWarningTimestamp,
@@ -647,7 +728,7 @@ public class Account: WebHookEvent {
             creationTimestamp: creationTimestamp, warn: warn, warnExpireTimestamp: warnExpireTimestamp,
             warnMessageAcknowledged: warnMessageAcknowledged,
             suspendedMessageAcknowledged: suspendedMessageAcknowledged, wasSuspended: wasSuspended, banned: banned,
-            lastUsedTimestamp: lastUsedTimestamp, group: group)
+            lastUsedTimestamp: lastUsedTimestamp, disabled: disabled, lastDisabled: lastDisabled, group: group)
     }
 
     public static func getNewCount(mysql: MySQL?=nil) throws -> Int64 {
@@ -664,12 +745,12 @@ public class Account: WebHookEvent {
             WHERE
                 first_warning_timestamp is NULL AND
                 failed_timestamp is NULL and device.uuid IS NULL AND
+                (disabled = 0 OR (disabled = 1 AND last_disabled <= UNIX_TIMESTAMP() - \(Account.disablePeriod))) AND
                 (
                     (failed IS NULL AND first_warning_timestamp is NULL) OR
                     (failed = 'GPR_RED_WARNING' AND warn_expire_timestamp IS NOT NULL AND
                      warn_expire_timestamp != 0 AND warn_expire_timestamp <= UNIX_TIMESTAMP()) OR
-                    (failed = 'suspended' AND failed_timestamp <= UNIX_TIMESTAMP() - \(Account.suspendedPeriod)) OR
-                    (failed = 'unknown' AND failed_timestamp <= UNIX_TIMESTAMP() - \(Account.unknownPeriod))
+                    (failed = 'suspended' AND failed_timestamp <= UNIX_TIMESTAMP() - \(Account.suspendedPeriod))
                 ) AND (
                     last_encounter_time IS NULL OR
                     UNIX_TIMESTAMP() - CAST(last_encounter_time AS SIGNED INTEGER) >= 7200 AND
@@ -839,9 +920,7 @@ public class Account: WebHookEvent {
         let sql = """
             SELECT COUNT(*)
             FROM account
-            WHERE
-                failed IS NOT NULL AND
-                (failed <> 'unknown' OR failed_timestamp >= UNIX_TIMESTAMP() - \(Account.unknownPeriod))
+            WHERE failed IS NOT NULL
         """
 
         let mysqlStmt = MySQLStmt(mysql)
@@ -874,7 +953,7 @@ public class Account: WebHookEvent {
                   (failed = 'GPR_RED_WARNING' AND warn_expire_timestamp IS NOT NULL AND
                    warn_expire_timestamp != 0 AND warn_expire_timestamp <= UNIX_TIMESTAMP()) OR
                   (failed = 'suspended' AND failed_timestamp <= UNIX_TIMESTAMP() - \(Account.suspendedPeriod)) OR
-                  (failed = 'unknown' AND failed_timestamp <= UNIX_TIMESTAMP() - \(Account.unknownPeriod))
+                  (disabled = 0 OR (disabled = 1 AND last_disabled <= UNIX_TIMESTAMP() - \(Account.disablePeriod)))
               ) as good,
               SUM(failed IN('banned', 'GPR_BANNED')) as banned,
               SUM(first_warning_timestamp IS NOT NULL) as warning,

--- a/Sources/RealDeviceMapLib/Modell/Account.swift
+++ b/Sources/RealDeviceMapLib/Modell/Account.swift
@@ -850,6 +850,33 @@ public class Account: WebHookEvent {
         return count
     }
 
+    public static func getDisabledCount(mysql: MySQL?=nil) throws -> Int64 {
+
+        guard let mysql = mysql ?? DBController.global.mysql else {
+            Log.error(message: "[ACCOUNT] Failed to connect to database.")
+            throw DBController.DBError()
+        }
+
+        let sql = """
+                      SELECT COUNT(*)
+                      FROM account
+                      WHERE disabled = 1 AND last_disabled > UNIX_TIMESTAMP() - \(Account.disablePeriod)
+                  """
+
+        let mysqlStmt = MySQLStmt(mysql)
+        _ = mysqlStmt.prepare(statement: sql)
+
+        guard mysqlStmt.execute() else {
+            Log.error(message: "[ACCOUNT] Failed to execute query 'getDisabledCount'. (\(mysqlStmt.errorMessage())")
+            throw DBController.DBError()
+        }
+        let results = mysqlStmt.results()
+        let result = results.next()!
+        let count = result[0] as! Int64
+
+        return count
+    }
+
     public static func getLevelCount(mysql: MySQL?=nil, level: Int) throws -> Int64 {
 
         guard let mysql = mysql ?? DBController.global.mysql else {

--- a/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
@@ -3914,12 +3914,10 @@ public class WebRequestHandler {
             if rowSplit.count == 2 {
                 let username = rowSplit[0].trimmingCharacters(in: .whitespaces)
                 let password = rowSplit[1].trimmingCharacters(in: .whitespaces)
-                accs.append(Account(username: username, password: password, level: level, firstWarningTimestamp: nil,
-                                    failedTimestamp: nil, failed: nil, lastEncounterLat: nil, lastEncounterLon: nil,
-                                    lastEncounterTime: nil, spins: 0, creationTimestamp: nil, warn: nil,
-                                    warnExpireTimestamp: nil, warnMessageAcknowledged: nil,
-                                    suspendedMessageAcknowledged: nil, wasSuspended: nil, banned: nil,
-                                    lastUsedTimestamp: nil, group: group))
+                if username.count > 0 && password.count > 0 {
+                    accs.append(Account(username: username, password: password, level: level, spins: 0,
+                        disabled: false, group: group))
+                }
             }
         }
 
@@ -3929,9 +3927,7 @@ public class WebRequestHandler {
             return data
         } else {
             do {
-                for acc in accs {
-                    try acc.save(update: false)
-                }
+                try Account.insertAccountBatch(accounts: accs)
             } catch {
                 data["show_error"] = true
                 data["error"] = "Failed to save accounts."

--- a/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
@@ -1277,8 +1277,8 @@ public class WebRequestHandler {
             data["failed_accounts_count"] = (try? Account.getFailedCount().withCommas()) ?? "?"
             data["cooldown_accounts_count"] = (try? Account.getCooldownCount().withCommas()) ?? "?"
             data["spin_limit_accounts_count"] = (try? Account.getSpinLimitCount().withCommas()) ?? "?"
+            data["disabled_accounts_count"] = (try? Account.getDisabledCount().withCommas()) ?? "?"
             data["iv_accounts_count"] = (try? Account.getLevelCount(level: 30).withCommas()) ?? "?"
-            data["iv_40_accounts_count"] = (try? Account.getLevelCount(level: 40).withCommas()) ?? "?"
             data["stats"] = (try? Account.getStats()) ?? ""
             data["ban_stats"] = (try? Account.getWarningBannedStats()) ?? ""
         case .dashboardAccountsAdd:

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -50,6 +50,16 @@ public func setupRealDeviceMap() {
     Log.info(message: "[MAIN] Starting Database Controller")
     _ = DBController.global
 
+    if let accMaxEncounters: Int = ConfigLoader.global.getConfig(type: .accMaxEncounters), accMaxEncounters > 0 {
+        Log.info(message: "[MAIN] Account switching after \(accMaxEncounters) encounters enabled.")
+        do {
+            // to keep track of the right count all previously used accounts has to be disabled on startup
+            try Account.setDisabledOnUsed()
+        } catch {
+            Log.warning(message: "[MAIN] Failed to disable used accounts on startup.")
+        }
+    }
+
     // Init MemoryCache
     let memoryCacheEnabled: Bool = ConfigLoader.global.getConfig(type: .memoryCacheEnabled)
     let memoryCacheClearInterval = (ConfigLoader.global.getConfig(type: .memoryCacheClearInterval) as Int).toDouble()

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -50,7 +50,8 @@ public func setupRealDeviceMap() {
     Log.info(message: "[MAIN] Starting Database Controller")
     _ = DBController.global
 
-    if let accMaxEncounters: Int = ConfigLoader.global.getConfig(type: .accMaxEncounters), accMaxEncounters > 0 {
+    let accMaxEncounters: Int = ConfigLoader.global.getConfig(type: .accMaxEncounters)
+    if accMaxEncounters > 0 {
         Log.info(message: "[MAIN] Account switching after \(accMaxEncounters) encounters enabled.")
         do {
             // to keep track of the right count all previously used accounts has to be disabled on startup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 #     PVP_LEVEL_CAPS: 40,50,51 #default only 50
 #     QUEST_RETRY_LIMIT: 10
 #     SPIN_DISTANCE: 80
-#     ACC_MAX_ENCOUNTERS: 7000
+#     ACC_MAX_ENCOUNTERS: 0
 #     ACC_DISABLE_PERIOD: 86400
 ### Uncommenting the following lines will set these values to TRUE (regardless of their value)
 #     USE_RW_FOR_QUEST: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
 #     PVP_LEVEL_CAPS: 40,50,51 #default only 50
 #     QUEST_RETRY_LIMIT: 10
 #     SPIN_DISTANCE: 80
+#     ACC_MAX_ENCOUNTERS: 7000
+#     ACC_DISABLE_PERIOD: 86400
 ### Uncommenting the following lines will set these values to TRUE (regardless of their value)
 #     USE_RW_FOR_QUEST: 1
 #     USE_RW_FOR_RAID: 1

--- a/resources/config/default.json
+++ b/resources/config/default.json
@@ -43,7 +43,9 @@
       "requireInDB": true,
       "useRwForQuest": false,
       "useRwForRaid": false,
-      "useRwForPokes": false
+      "useRwForPokes": false,
+      "maxEncounters": 7000,
+      "disablePeriod": 86400
     },
     "loginLimit": {
       "enabled": false,

--- a/resources/config/default.json
+++ b/resources/config/default.json
@@ -44,7 +44,7 @@
       "useRwForQuest": false,
       "useRwForRaid": false,
       "useRwForPokes": false,
-      "maxEncounters": 7000,
+      "maxEncounters": 0,
       "disablePeriod": 86400
     },
     "loginLimit": {

--- a/resources/migrations/98.sql
+++ b/resources/migrations/98.sql
@@ -1,0 +1,7 @@
+ALTER TABLE account
+    ADD COLUMN `disabled` tinyint(1) unsigned DEFAULT 0 AFTER `last_used_timestamp`,
+    ADD COLUMN `last_disabled` int unsigned DEFAULT NULL AFTER `disabled`;
+
+UPDATE account
+    SET failed = NULL, failed_timestamp = NULL
+    WHERE failed = 'unknown';

--- a/resources/migrations/98.sql
+++ b/resources/migrations/98.sql
@@ -3,5 +3,5 @@ ALTER TABLE account
     ADD COLUMN `last_disabled` int unsigned DEFAULT NULL AFTER `disabled`;
 
 UPDATE account
-    SET failed = NULL, failed_timestamp = NULL
+    SET failed = NULL, failed_timestamp = NULL, disabled = 1, last_disabled = UNIX_TIMESTAMP()
     WHERE failed = 'unknown';

--- a/resources/webroot/dashboard_accounts.mustache
+++ b/resources/webroot/dashboard_accounts.mustache
@@ -51,8 +51,8 @@
             <div class="col-md-3 p-1">
               <div class="list-group">
                 <a class="list-group-item">
-                  <h4 class="list-group-item-heading" style="color: teal;">{{iv_40_accounts_count}}</h4>
-                  <p class="list-group-item-text">Total over Level 40</p>
+                  <h4 class="list-group-item-heading" style="color: orange;">{{disabled_accounts_count}}</h4>
+                  <p class="list-group-item-text">Disabled Accounts</p>
                 </a>
               </div>
             </div>


### PR DESCRIPTION
New Feature to disable accounts (this feature is disabled by default):
- disable accounts when it reaches a specific amount of encounters (9k)
- don't use those accounts for 24 hours
- both values (9k and 24h) can be configured in ENV VARS or local.json

MITM can still return right control handle to disable accounts for 24 hours, when blue-screen is happening