### PR TITLE
Make disabling account after receiving an RPC 12 from MITM optional

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
+++ b/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
@@ -23,7 +23,8 @@ public class ConfigLoader {
         "USE_RW_FOR_QUEST", "USE_RW_FOR_RAID", "NO_GENERATE_IMAGES", "NO_PVP", "NO_IV_WEATHER_CLEARING",
         "NO_CELL_POKEMON", "SAVE_SPAWNPOINT_LASTSEEN", "NO_MEMORY_CACHE", "NO_BACKUP", "NO_REQUIRE_ACCOUNT",
         "SCAN_LURE_ENCOUNTER", "QUEST_RETRY_LIMIT", "SPIN_DISTANCE", "ALLOW_AR_QUESTS", "STOP_ALL_BOOTSTRAPPING",
-        "USE_RW_FOR_POKES", "NO_DB_CLEARER", "NO_DB_CLEARER_INCIDENT", "ACC_MAX_ENCOUNTERS", "ACC_DISABLE_PERIOD"
+        "USE_RW_FOR_POKES", "NO_DB_CLEARER", "NO_DB_CLEARER_INCIDENT", "ACC_MAX_ENCOUNTERS", "ACC_DISABLE_PERIOD",
+        "ACC_DISABLE_ON_UNK_ERROR"
     ]
 
     private init() {
@@ -92,6 +93,8 @@ public class ConfigLoader {
             ?? defaultConfig.application.account.maxEncounters.value()!
         case .accDisablePeriod: return localConfig.application.account.disablePeriod.value()
             ?? defaultConfig.application.account.disablePeriod.value()!
+        case .accDisableOnUnkError: return localConfig.application.account.disableOnUnkError.value()
+            ?? defaultConfig.application.account.disableOnUnkError.value()!
         case .loginLimit: return localConfig.application.loginLimit.enabled.value()
             ?? defaultConfig.application.loginLimit.enabled.value()!
         case .loginLimitCount: return localConfig.application.loginLimit.count.value()
@@ -189,6 +192,7 @@ public class ConfigLoader {
         case .accUseRwForRaid: return false as! T // USE_RW_FOR_RAID
         case .accMaxEncounters: return castValue(value: value)
         case .accDisablePeriod: return castValue(value: value)
+        case .accDisableOnUnkError: return true as! T // ACC_DISABLE_ON_UNK_ERROR
         case .loginLimit: return false as! T
         case .loginLimitCount: return castValue(value: value)
         case .loginLimitInterval: return castValue(value: value)
@@ -267,6 +271,7 @@ public class ConfigLoader {
         case accUseRwForRaid = "USE_RW_FOR_RAID"
         case accMaxEncounters = "ACC_MAX_ENCOUNTERS"
         case accDisablePeriod = "ACC_DISABLE_PERIOD"
+        case accDisableOnUnkError = "ACC_DISABLE_ON_UNK_ERROR"
         case loginLimit = "LOGIN_LIMIT" // not used in env
         case loginLimitCount = "LOGINLIMIT_COUNT"
         case loginLimitInterval = "LOGINLIMIT_INTERVALL"

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -54,6 +54,7 @@ public class WebHookRequestHandler {
     private static let encounterLock = Threading.Lock()
     private static var encounterCount = [String: Int]()
     private static let maxEncounter: Int = ConfigLoader.global.getConfig(type: .accMaxEncounters)
+    private static let accDisableOnUnkError: Bool = ConfigLoader.global.getConfig(type: .accDisableOnUnkError)
 
     private static let questArTargetMap = TimedMap<String, Bool>(length: 100)
     private static let questArActualMap = TimedMap<String, Bool>(length: 100)
@@ -1176,7 +1177,7 @@ public class WebHookRequestHandler {
             } catch {
                 response.respondWithError(status: .internalServerError)
             }
-        } else if type == "account_unknown_error" {
+        } else if type == "account_unknown_error" && accDisableOnUnkError {
             // accounts are stuck in e.g. blue maintenance screen, make them invalid for at least one day
             do {
                 guard

--- a/resources/config/default.json
+++ b/resources/config/default.json
@@ -45,7 +45,8 @@
       "useRwForRaid": false,
       "useRwForPokes": false,
       "maxEncounters": 0,
-      "disablePeriod": 86400
+      "disablePeriod": 86400,
+      "disableOnUnkError": true
     },
     "loginLimit": {
       "enabled": false,


### PR DESCRIPTION


## Description
Adds a new option to docker-compose.yml (ACC_DISABLE_ON_UNK_ERROR) and local.json (disableOnUnkError) to provide the option to either disable the accounts when they receive an rpc code: 12 or not. The default setting is true to align with the way the rpc code: 12 is currently handled. By setting disableOnUnkError to false, accounts will not be disabled when they receive rpc code: 12. Encounter limit functionality has not been changed.

## Motivation and Context
My account were receiving rpc code: 12 from 1-5 times in a row causing them to be disabled. When I hand checked the accounts they did not have the maintenance screen. Since encounter limits made things stable, I wanted to have a way to run new versions of MITM with the encounter limit.

## How Has This Been Tested?
I built the image and tested on my local setup. I have already observed accounts receiving multiple rpc code 12, not logging out, and being able to function with the same account

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
