### PR TITLE
Set limit for rpc code 12 before disabling

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
+++ b/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
@@ -23,7 +23,8 @@ public class ConfigLoader {
         "USE_RW_FOR_QUEST", "USE_RW_FOR_RAID", "NO_GENERATE_IMAGES", "NO_PVP", "NO_IV_WEATHER_CLEARING",
         "NO_CELL_POKEMON", "SAVE_SPAWNPOINT_LASTSEEN", "NO_MEMORY_CACHE", "NO_BACKUP", "NO_REQUIRE_ACCOUNT",
         "SCAN_LURE_ENCOUNTER", "QUEST_RETRY_LIMIT", "SPIN_DISTANCE", "ALLOW_AR_QUESTS", "STOP_ALL_BOOTSTRAPPING",
-        "USE_RW_FOR_POKES", "NO_DB_CLEARER", "NO_DB_CLEARER_INCIDENT", "ACC_MAX_ENCOUNTERS", "ACC_DISABLE_PERIOD"
+        "USE_RW_FOR_POKES", "NO_DB_CLEARER", "NO_DB_CLEARER_INCIDENT", "ACC_MAX_ENCOUNTERS", "ACC_DISABLE_PERIOD",
+        "ACC_MAX_RPC12"
     ]
 
     private init() {
@@ -92,6 +93,8 @@ public class ConfigLoader {
             ?? defaultConfig.application.account.maxEncounters.value()!
         case .accDisablePeriod: return localConfig.application.account.disablePeriod.value()
             ?? defaultConfig.application.account.disablePeriod.value()!
+        case .accMaxRpc12: return localConfig.application.account.maxRpc12.value()
+            ?? defaultConfig.application.account.maxRpc12.value()!
         case .loginLimit: return localConfig.application.loginLimit.enabled.value()
             ?? defaultConfig.application.loginLimit.enabled.value()!
         case .loginLimitCount: return localConfig.application.loginLimit.count.value()
@@ -189,6 +192,7 @@ public class ConfigLoader {
         case .accUseRwForRaid: return false as! T // USE_RW_FOR_RAID
         case .accMaxEncounters: return castValue(value: value)
         case .accDisablePeriod: return castValue(value: value)
+        case .accMaxRpc12: return castValue(value: value)
         case .loginLimit: return false as! T
         case .loginLimitCount: return castValue(value: value)
         case .loginLimitInterval: return castValue(value: value)
@@ -267,6 +271,7 @@ public class ConfigLoader {
         case accUseRwForRaid = "USE_RW_FOR_RAID"
         case accMaxEncounters = "ACC_MAX_ENCOUNTERS"
         case accDisablePeriod = "ACC_DISABLE_PERIOD"
+        case accMaxRpc12 = "ACC_MAX_RPC12"
         case loginLimit = "LOGIN_LIMIT" // not used in env
         case loginLimitCount = "LOGINLIMIT_COUNT"
         case loginLimitInterval = "LOGINLIMIT_INTERVALL"

--- a/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
@@ -3915,8 +3915,7 @@ public class WebRequestHandler {
                 let username = rowSplit[0].trimmingCharacters(in: .whitespaces)
                 let password = rowSplit[1].trimmingCharacters(in: .whitespaces)
                 if username.count > 0 && password.count > 0 {
-                    accs.append(Account(username: username, password: password, level: level, spins: 0,
-                        disabled: false, group: group))
+                    accs.append(Account(username: username, password: password, level: level, spins: 0, group: group))
                 }
             }
         }

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -592,7 +592,9 @@ public class WebHookRequestHandler {
         }
 
         if username != nil && encounters.count > 0 && (rpc12Count[username!] ?? 0) > 0 {
-            rpc12Count[username!] = 0
+            rpc12Lock.doWithLock {
+                rpc12Count[username!] = 0
+            }
             Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] [\(username!)] #RPC12 Reset")
         }
 

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1064,7 +1064,7 @@ public class WebHookRequestHandler {
                     if InstanceController.global.accountValid(deviceUUID: uuid, account: oldAccount) {
                         account = oldAccount
                     } else {
-                        rpc12Count.removeValue(forKey: oldAccount.username)
+                        rpc12Lock.doWithLock { rpc12Count.removeValue(forKey: oldAccount.username) }
                         Log.debug(
                             message: "[WebHookRequestHandler] [\(uuid)] Previously Assigned Account " +
                                      "\(oldAccount.username) not valid for Instance " +

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1257,11 +1257,9 @@ public class WebHookRequestHandler {
                     response.respondWithError(status: .notFound)
                     return
                 }
-                if (rpc12Count[device.accountUsername!] ?? 0) == 0 {
-                    device.accountUsername = nil
-                    try device.save(mysql: mysql, oldUUID: device.uuid)
-                    response.respondWithOk()
-                }
+                device.accountUsername = nil
+                try device.save(mysql: mysql, oldUUID: device.uuid)
+                response.respondWithOk()
             } catch {
                 response.respondWithError(status: .internalServerError)
             }

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -557,11 +557,9 @@ public class WebHookRequestHandler {
                 encounter.pokemon.encounterID.description == pokemonEncounterIdForEncounter {
                 // We actually encountered the target.
                 data["encounters"] = 1
-                if username != nil && rpc12Count[username!] > 0 {
-                    rpc12Lock.doWithLock {
-                        rpc12Count[username!] = 0
-                        Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] [\(username!)] #RPC12 Reset")
-                    }
+                if username != nil && rpc12Count[username!] != nil {
+                    rpc12Count.removeValue(forKey: username!)
+                    Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] [\(username!)] #RPC12 Reset")
                 }
             }
         }
@@ -1222,7 +1220,7 @@ public class WebHookRequestHandler {
                     var value: Int = (rpc12Count[username!] ?? 0) + 1
                     if value < maxRpc12 {
                         rpc12Count[username!] = value
-                        Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] [\(username!)] #RPC12: \(value)")
+                        Log.debug(message: "[WebHookRequestHandler] [\(uuid)] [\(username!)] #RPC12: \(value)")
                     } else {
                         do {
                             guard
@@ -1235,7 +1233,7 @@ public class WebHookRequestHandler {
                             }
 
                             Log.warning(message: "[WebHookRequestHandler] [\(uuid)] Account stuck in blue screen: \(username)")
-                            rpc12Count.removeValue(forKey: username!)
+                            rpc12Count.removeValue(forKey: username)
                             try Account.setDisabled(mysql: mysql, username: username)
                             response.respondWithOk()
                         } catch {
@@ -1252,7 +1250,7 @@ public class WebHookRequestHandler {
                     response.respondWithError(status: .notFound)
                     return
                 }
-                rpc12Count.removeValue(forKey: device.accountUsername)
+                rpc12Count.removeValue(forKey: device.accountUsername!)
                 device.accountUsername = nil
                 try device.save(mysql: mysql, oldUUID: device.uuid)
                 response.respondWithOk()

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -557,6 +557,12 @@ public class WebHookRequestHandler {
                 encounter.pokemon.encounterID.description == pokemonEncounterIdForEncounter {
                 // We actually encountered the target.
                 data["encounters"] = 1
+                if username != nil && rpc12Count[username!] > 0 {
+                    rpc12Lock.doWithLock {
+                        rpc12Count[username!] = 0
+                        Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] [\(username!)] #RPC12 Reset")
+                    }
+                }
             }
         }
 
@@ -1216,7 +1222,7 @@ public class WebHookRequestHandler {
                     var value: Int = (rpc12Count[username!] ?? 0) + 1
                     if value < maxRpc12 {
                         rpc12Count[username!] = value
-                        Log.debug(message: "[WebHookRequestHandler] [\(uuid0 ?? "?")] [\(username!)] #RPC 12 Count: \(value)")
+                        Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] [\(username!)] #RPC12: \(value)")
                     } else {
                         do {
                             guard
@@ -1229,6 +1235,7 @@ public class WebHookRequestHandler {
                             }
 
                             Log.warning(message: "[WebHookRequestHandler] [\(uuid)] Account stuck in blue screen: \(username)")
+                            rpc12Count.removeValue(forKey: username!)
                             try Account.setDisabled(mysql: mysql, username: username)
                             response.respondWithOk()
                         } catch {
@@ -1245,6 +1252,7 @@ public class WebHookRequestHandler {
                     response.respondWithError(status: .notFound)
                     return
                 }
+                rpc12Count.removeValue(forKey: device.accountUsername)
                 device.accountUsername = nil
                 try device.save(mysql: mysql, oldUUID: device.uuid)
                 response.respondWithOk()

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1237,8 +1237,8 @@ public class WebHookRequestHandler {
                                 return
                             }
 
-                            Log.warning(message: """[WebHookRequestHandler] [\(uuid)]
-                                 Account exceeded RPC12 Limit, disabling: \(username)""")
+                            Log.warning(message: "[WebHookRequestHandler] [\(uuid)]
+                                 Account exceeded RPC12 Limit, disabling: \(username)")
                             rpc12Count.removeValue(forKey: username)
                             try Account.setDisabled(mysql: mysql, username: username)
                             response.respondWithOk()

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -585,7 +585,7 @@ public class WebHookRequestHandler {
 
         if username != nil && maxEncounter > 0 {
             encounterLock.doWithLock {
-                var value: Int = (encounterCount[username!] ?? 0) + encounters.count + encountersBelowLevelThirty
+                let value = (encounterCount[username!] ?? 0) + encounters.count + encountersBelowLevelThirty
                 if value < maxEncounter {
                     encounterCount[username!] = value
                     Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] [\(username!)] #Encounter: \(value)")
@@ -1237,12 +1237,12 @@ public class WebHookRequestHandler {
                     let value = (rpc12Count[username] ?? 0) + 1
                     if value < maxRpc12 {
                         rpc12Count[username] = value
-                        Log.debug(message: "[WebHookRequestHandler] [\(uuid)] [\(username!)] #RPC12: \(value)")
+                        Log.debug(message: "[WebHookRequestHandler] [\(uuid)] [\(username)] #RPC12: \(value)")
                     } else {
                         Log.warning(message: "[WebHookRequestHandler] [\(uuid)] Account exceeded RPC12 " +
                             "Limit, disabling: \(username)")
                         rpc12Count.removeValue(forKey: username)
-                        try Account.setDisabled(mysql: mysql, username: username)
+                        try? Account.setDisabled(mysql: mysql, username: username)
                     }
                 }
                 response.respondWithOk()

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1220,7 +1220,6 @@ public class WebHookRequestHandler {
             }
         } else if type == "account_unknown_error" {
             // accounts are stuck in e.g. blue maintenance screen, make them invalid for at least one day
-            
             if username != nil && maxRpc12 > 0 {
                 rpc12Lock.doWithLock {
                     var value: Int = (rpc12Count[username!] ?? 0) + 1
@@ -1238,7 +1237,8 @@ public class WebHookRequestHandler {
                                 return
                             }
 
-                            Log.warning(message: "[WebHookRequestHandler] [\(uuid)] Account exceeded RPC12 Limit, disabling: \(username)")
+                            Log.warning(message: """[WebHookRequestHandler] [\(uuid)]
+                                 Account exceeded RPC12 Limit, disabling: \(username)""")
                             rpc12Count.removeValue(forKey: username)
                             try Account.setDisabled(mysql: mysql, username: username)
                             response.respondWithOk()
@@ -1247,7 +1247,7 @@ public class WebHookRequestHandler {
                         }
                     }
                 }
-            }           
+            }
         } else if type == "logged_out" {
             do {
                 guard

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -582,6 +582,7 @@ public class WebHookRequestHandler {
                 var value: Int = (encounterCount[username!] ?? 0) + encounters.count
                 if value < maxEncounter {
                     encounterCount[username!] = value
+                    Log.debug(message: "[WebHookRequestHandler] [\(uuid ?? "?")] [\(username!)] #Encounter: \(value)")
                 } else {
                     try? Account.setDisabled(mysql: mysql, username: username!)
                     encounterCount.removeValue(forKey: username!)

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1252,7 +1252,7 @@ public class WebHookRequestHandler {
                     return
                 }
                 if device.accountUsername != nil {
-                    rpc12Count.removeValue(forKey: device.accountUsername)
+                    rpc12Count.removeValue(forKey: device.accountUsername!)
                 }
                 device.accountUsername = nil
                 try device.save(mysql: mysql, oldUUID: device.uuid)

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1237,8 +1237,8 @@ public class WebHookRequestHandler {
                                 return
                             }
 
-                            Log.warning(message: "[WebHookRequestHandler] [\(uuid)]
-                                 Account exceeded RPC12 Limit, disabling: \(username)")
+                            Log.warning(message: "[WebHookRequestHandler] [\(uuid)] " +
+                                "Account exceeded RPC12 Limit, disabling: \(username)")
                             rpc12Count.removeValue(forKey: username)
                             try Account.setDisabled(mysql: mysql, username: username)
                             response.respondWithOk()

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -51,7 +51,8 @@ public func setupRealDeviceMap() {
     _ = DBController.global
 
     let accMaxEncounters: Int = ConfigLoader.global.getConfig(type: .accMaxEncounters)
-    if accMaxEncounters > 0 {
+    let accMaxRpc12: Int = ConfigLoader.global.getConfig(type: .accMaxRpc12)
+    if accMaxEncounters > 0 && accMaxRpc12 > 1 {
         Log.info(message: "[MAIN] Account switching after \(accMaxEncounters) encounters enabled.")
         do {
             // to keep track of the right count all previously used accounts has to be disabled on startup

--- a/resources/config/default.json
+++ b/resources/config/default.json
@@ -46,7 +46,7 @@
       "useRwForPokes": false,
       "maxEncounters": 0,
       "disablePeriod": 86400,
-      "maxRpc12": 1
+      "maxRpc12": 5
     },
     "loginLimit": {
       "enabled": false,

--- a/resources/config/default.json
+++ b/resources/config/default.json
@@ -45,7 +45,8 @@
       "useRwForRaid": false,
       "useRwForPokes": false,
       "maxEncounters": 0,
-      "disablePeriod": 86400
+      "disablePeriod": 86400,
+      "maxRpc12": 0
     },
     "loginLimit": {
       "enabled": false,

--- a/resources/config/default.json
+++ b/resources/config/default.json
@@ -46,7 +46,7 @@
       "useRwForPokes": false,
       "maxEncounters": 0,
       "disablePeriod": 86400,
-      "maxRpc12": 0
+      "maxRpc12": 1
     },
     "loginLimit": {
       "enabled": false,


### PR DESCRIPTION
The goal was to enable setting a maximum number of RPC code 12 before disabling an account

## Description
The number of RPC code 12s are counted. This number is compared to a limit set in local.json (maxRpc12). If the number of RPC code 12 exceeds the limit, the account is disabled. The RPC code 12 count is reset upon the account successfully encountering. I recommend setting maxRpc12 to 15 - 20 to make sure I'm not getting too many false positives because (at least in my case) rpc12s come in sets of 5. So, setting to 15 will give the account three chances to make an encounter before disabling the account. This works even if the MITM forces a log out.


## Motivation and Context
RPC code 12 is sent during blue maintenance screen but also other random times. False positives lead to way too many accounts being disabled and leveling not being able to be completed. This PR should help for more accurate detection of when an account is truly on the blue screen 


## How Has This Been Tested?
I tested this in a test environment with a single device in leveling, circle smart, and questing. In leveling and questing I have observed correct handling of both "false positive" rpc12s (accounts are fine) and true rpc12s (accounts stuck on maintenance screen). I disabled the encounter limit. Upon hitting the rpc12Max, accounts were disabled. Encounters both during leveling and circle smart reset the rpc12cout. I need to do more testing for questing, but thus far I haven't had any issues.




## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix any issues they point out. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
