### PR TITLE
Remove last_seen Updates from Heartbeats

### DIFF
--- a/Sources/RealDeviceMapLib/Modell/Device.swift
+++ b/Sources/RealDeviceMapLib/Modell/Device.swift
@@ -58,7 +58,7 @@ public class Device: JSONConvertibleObject, Hashable {
         let mysqlStmt = MySQLStmt(mysql)
         let sql = """
                 UPDATE device
-                SET last_host = ?, last_seen = UNIX_TIMESTAMP()
+                SET last_host = ?
                 WHERE uuid = ?
             """
         _ = mysqlStmt.prepare(statement: sql)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Heartbeats haven't really been used since the UIC days but Atlas sends them now and they update the last_seen timestamp. Atlas sends them even if a device isn't doing what it should be like trying to swap accounts when there aren't any. Making the device appear falsely online when it's not moving. Since we have other ways to keep the last_seen accurate, disabling this hurts nothing and improves device monitoring.
