### PR TITLE
Force a device api secret on setup

### DIFF
--- a/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Web/WebRequestHandler.swift
@@ -1969,6 +1969,9 @@ public class WebRequestHandler {
                 }
                 if useAccessToken {
                     try DBController.global.setValueForKey(key: "IS_SETUP", value: "true")
+                    try DBController.global.setValueForKey(
+                        key: "DEVICEAPI_SECRET",
+                        value: WebHookRequestHandler.loginSecret!)
                     WebRequestHandler.isSetup = true
                     WebRequestHandler.accessToken = nil
                     response.redirect(path: "/")

--- a/Sources/RealDeviceMapLib/setup.swift
+++ b/Sources/RealDeviceMapLib/setup.swift
@@ -345,6 +345,7 @@ public func setupRealDeviceMap() {
     } else {
         WebRequestHandler.isSetup = false
         WebRequestHandler.accessToken = URandom().secureToken
+        WebHookRequestHandler.loginSecret = WebHookRequestHandler.loginSecret ?? WebRequestHandler.accessToken
         Log.info(message: "[MAIN] Use this access-token to create the admin user: \(WebRequestHandler.accessToken!)")
     }
 


### PR DESCRIPTION
Many people run RDM without device api secret - force a new setup with enabled secret