### PR TITLE
remove account from encounter counter if got disabled

### DIFF
--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1226,6 +1226,7 @@ public class WebHookRequestHandler {
                 }
 
                 try Account.setDisabled(mysql: mysql, username: username)
+                encounterCount.removeValue(forKey: username)
                 guard let controller = InstanceController.global.getInstanceController(deviceUUID: uuid) else {
                     response.respondWithError(status: .internalServerError)
                     return

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -1226,7 +1226,7 @@ public class WebHookRequestHandler {
                 }
 
                 try Account.setDisabled(mysql: mysql, username: username)
-                encounterCount.removeValue(forKey: username)
+                encounterLock.doWithLock { encounterCount.removeValue(forKey: username) }
                 guard let controller = InstanceController.global.getInstanceController(deviceUUID: uuid) else {
                     response.respondWithError(status: .internalServerError)
                     return


### PR DESCRIPTION
right now we only delete the encounter count cache if we use encounter count and we hit the limit
but we don't delete it if MITM reports BSOD, so this encounter count cache is growing over time when we use encounter limit but BSOD comes first.

hopefully this will reduce memory leak