### PR TITLE
new config to disable processing of pokemon/incidents

### DIFF
--- a/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
+++ b/Sources/RealDeviceMapLib/Misc/ConfigLoader.swift
@@ -162,6 +162,10 @@ public class ConfigLoader {
             ?? defaultConfig.application.quest.questRetryLimit.value()!
         case .spinDistance: return localConfig.application.quest.spinDistance.value()
             ?? defaultConfig.application.quest.spinDistance.value()!
+        case .processPokemon: return localConfig.application.process.pokemon.value()
+            ?? defaultConfig.application.process.pokemon.value()!
+        case .processIncident: return localConfig.application.process.incident.value()
+            ?? defaultConfig.application.process.incident.value()!
         }
     }
 
@@ -224,6 +228,8 @@ public class ConfigLoader {
         case .accUseRwForPokes: return false as! T // USE_RW_FOR_POKES
         case .questRetryLimit: return castValue(value: value) // QUEST_RETRY_LIMIT
         case .spinDistance: return castValue(value: value) // SPIN_DISTANCE
+        case .processPokemon: return true as! T
+        case .processIncident: return true as! T
         }
     }
 
@@ -302,6 +308,8 @@ public class ConfigLoader {
         case accUseRwForPokes = "USE_RW_FOR_POKES"
         case questRetryLimit = "QUEST_RETRY_LIMIT"
         case spinDistance = "SPIN_DISTANCE"
+        case processPokemon = "PROCESS_POKEMON" // not used in env
+        case processIncident = "PROCESS_INCIDENT" // not used in env
     }
 
 }

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -579,6 +579,14 @@ public class WebHookRequestHandler {
             response.respondWithError(status: .internalServerError)
         }
 
+        if let processPokemon: Bool = ConfigLoader.global.getConfig(type: .processPokemon), !processPokemon {
+            wildPokemons = [:]
+            nearbyPokemons = [:]
+            mapPokemons = [:]
+            encouters = [:]
+            diskEncounters = [:]
+        }
+
         if username != nil && maxEncounter > 0 {
             encounterLock.doWithLock {
                 let value = (encounterCount[username!] ?? 0) + encounters.count + encountersBelowLevelThirty
@@ -751,6 +759,7 @@ public class WebHookRequestHandler {
                 )
             }
 
+            let processIncident: Bool = ConfigLoader.global.getConfig(type: .processIncident)
             let startForts = Date()
             for fort in forts {
                 if fort.data.fortType == .gym {
@@ -769,7 +778,9 @@ public class WebHookRequestHandler {
                         ?? Pokestop()
                     pokestop.updateFromFort(fortData: fort.data, cellId: fort.cell)
                     try? pokestop.save(mysql: mysql)
-                    pokestop.incidents.forEach({ incident in try? incident.save(mysql: mysql) })
+                    if processIncident {
+                        pokestop.incidents.forEach({ incident in try? incident.save(mysql: mysql) })
+                    }
                     if stopsIdsPerCell[fort.cell] == nil {
                         stopsIdsPerCell[fort.cell] = [String]()
                     }

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -580,11 +580,11 @@ public class WebHookRequestHandler {
         }
 
         if let processPokemon: Bool = ConfigLoader.global.getConfig(type: .processPokemon), !processPokemon {
-            wildPokemons = []
-            nearbyPokemons = []
-            mapPokemons = []
-            encounters = []
-            diskEncounters = []
+            wildPokemons.removeAll()
+            nearbyPokemons.removeAll()
+            mapPokemons.removeAll()
+            encounters.removeAll()
+            diskEncounters.removeAll()
         }
 
         if username != nil && maxEncounter > 0 {

--- a/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
+++ b/Sources/RealDeviceMapLib/Webhook/WebHookRequestHandler.swift
@@ -580,11 +580,11 @@ public class WebHookRequestHandler {
         }
 
         if let processPokemon: Bool = ConfigLoader.global.getConfig(type: .processPokemon), !processPokemon {
-            wildPokemons = [:]
-            nearbyPokemons = [:]
-            mapPokemons = [:]
-            encouters = [:]
-            diskEncounters = [:]
+            wildPokemons = []
+            nearbyPokemons = []
+            mapPokemons = []
+            encounters = []
+            diskEncounters = []
         }
 
         if username != nil && maxEncounter > 0 {

--- a/resources/config/default.json
+++ b/resources/config/default.json
@@ -102,6 +102,10 @@
         "questRetryLimit": 10,
         "spinDistance": 80
     },
-    "stopAllBootstrapping": false
+    "stopAllBootstrapping": false,
+    "process": {
+      "pokemon": true,
+      "incident": true
+    }
   }
 }


### PR DESCRIPTION
For all the [Golbat](https://github.com/UnownHash/Golbat) lovers, to reduce load when using RDM along Golbat :) 

Only supported in JSON Config Usage :) 

To disable add those lines to the proper location within the `application` section

```json
{
  "application": {
    "process": {
      "pokemon": false,
      "incident": false
    }
  }
}
```