### PR TITLE
Change docker image to slim image as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN swift build -c release -Xswiftc -g
 # ================================
 # Run image
 # ================================
-FROM swift:5.4-focal
+FROM swift:5.4-focal-slim
 WORKDIR /app
 
 # Perfect-COpenSSL

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,26 +45,26 @@ RUN swift build -c release -Xswiftc -g
 FROM swift:5.4-focal-slim
 WORKDIR /app
 
+# Install dependencies for
 # Perfect-COpenSSL
-RUN apt-get -y update && apt-get install -y libssl-dev
-
 # Perfect-libcurl
-RUN apt-get -y update && apt-get install -y libcurl4-openssl-dev
-
 # Perfect-LinuxBridge
-RUN apt-get -y update && apt-get install -y uuid-dev && rm -rf /var/lib/apt/lists/*
-
 # ImageMagick for creating raid images
-RUN apt-get -y update && apt-get install -y imagemagick && cp /usr/bin/convert /usr/local/bin
-
 # WGet
-RUN apt-get -y update && apt-get install -y wget
-
 # MySQL Client
+
 RUN export DEBIAN_FRONTEND=noninteractive && \
 	apt-get -y update && \
-	apt-get install -y lsb-release mysql-client libmysqlclient-dev && \
-	sed -i -e 's/-fabi-version=2 -fno-omit-frame-pointer//g' /usr/lib/x86_64-linux-gnu/pkgconfig/mysqlclient.pc
+	apt-get install -y \
+	libssl-dev \
+	libcurl4-openssl-dev \
+	uuid-dev \
+	imagemagick \
+	wget \
+	lsb-release mysql-client libmysqlclient-dev && \
+	cp /usr/bin/convert /usr/local/bin && \
+	sed -i -e 's/-fabi-version=2 -fno-omit-frame-pointer//g' /usr/lib/x86_64-linux-gnu/pkgconfig/mysqlclient.pc && \
+	rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 # Copy build artifacts
 COPY --from=build /build/.build/release .


### PR DESCRIPTION
## Description
Slims down the docker image to 918MB instead of ~2.8GB
See [docker hub/swift](https://hub.docker.com/_/swift) Image Variants section for the difference between normal and -slim version. 
I also combined the seperate RUN apt-get etc statements into 1 to reduce the number of layers that gets created.

## How Has This Been Tested?
Running tests on my instance, see no errors and everything behaves as normal.
Startup felt faster but didn't measure it too much. 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
