### PR TITLE
RealDeviceMap overhaul, future proofing and maintaining.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ It also includes a basic proof of concept Instance and Device Manager.
 [Feature Requests](https://github.com/RealDeviceMap/RealDeviceMap/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
 
 Questions? Ask as in [Discord](https://discord.gg/q2aXaGP)
+

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/AutoInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/AutoInstanceController.swift
@@ -6,6 +6,7 @@
 //
 //  swiftlint:disable:next superfluous_disable_command
 //  swiftlint:disable file_length type_body_length function_body_length cyclomatic_complexity force_cast large_tuple
+// 
 
 import Foundation
 import PerfectLib

--- a/Sources/RealDeviceMapLib/Controller/InstanceControllers/IVInstanceController.swift
+++ b/Sources/RealDeviceMapLib/Controller/InstanceControllers/IVInstanceController.swift
@@ -6,6 +6,7 @@
 //
 //  swiftlint:disable:next superfluous_disable_command
 //  swiftlint:disable file_length type_body_length
+//
 
 import Foundation
 import PerfectLib

--- a/Sources/RealDeviceMapLib/Modell/Gym.swift
+++ b/Sources/RealDeviceMapLib/Modell/Gym.swift
@@ -6,6 +6,7 @@
 //
 //  swiftlint:disable:next superfluous_disable_command
 //  swiftlint:disable file_length type_body_length function_body_length cyclomatic_complexity force_cast
+//
 
 import Foundation
 import PerfectLib


### PR DESCRIPTION
## Description

With the help of an amazing team working day and night on this for the past year, this PR's aim is to update RDM with the tools needed to take back its place as the king of mapping.

While Swift has served us well, its intricacies and idiosyncrasies have posed challenges for many potential contributors. Recognizing the importance of opening our doors wider, we've decided to embrace a more community-friendly language.

### Key parts of this update include:

* Moving away from Swift. RDM was re-written in **Zig**, offering great performance benefits and saying goodbye to all those pesky memory leaks.
* Every Pokemon instance is an IV Queue instance now! Our tests have proven that doing circle scans makes the workers dizzy and fail too many GMOs.
* **MITM-less**, RDM can now generate infinite workers!!! (subject to your server hardware). Simply "Just add more workers!".

## Motivation and Context
RealDeviceMap has been more than just a tool; it's been a companion on our quest for exploration and discovery. Together, we've navigated the virtual landscape, uncovering hidden treasures and pushing the boundaries of what's possible.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by GitHub Actions, -->
<!--  run the following commands before you commit: `swiftlint` and `eslint`. Fix any issues they point out. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
